### PR TITLE
Implement native fingerprinting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ postgres.tar.bz2
 
 examples/*
 !examples/*.c
+
+test/*
+!test/*.c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-script: make examples
+script: make
 compiler:
   - clang
   - gcc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All versions are tagged by the major Postgres version, plus an individual semver for this library itself.
 
 
+## 9.5-1.1.0    UNRELEASED
+
+* Add pg_query_fingerprint() method that uniquely identifies SQL queries,
+  whilst ignoring formatting and individual constant values
+
+
 ## 9.5-1.0.0    2016-03-06
 
 * First release based on PostgreSQL 9.5.1

--- a/Makefile
+++ b/Makefile
@@ -72,13 +72,13 @@ ECHO = echo
 
 CC ?= cc
 
-all: $(ARLIB)
+all: examples test $(ARLIB)
 
 clean:
 	-@ $(RM) $(CLEANLIBS) $(CLEANOBJS) $(CLEANFILES) $(EXAMPLES)
 	-@ $(RM) -r $(PGDIR)
 
-.PHONY: all clean examples
+.PHONY: all clean examples test
 
 $(PGDIR): $(PGDIRBZ2)
 	tar -xjf $(PGDIRBZ2)
@@ -111,7 +111,8 @@ $(PGDIRBZ2):
 $(ARLIB): $(PGDIR) $(OBJS) Makefile
 	@$(AR) $@ $(ALL_OBJS)
 
-EXAMPLES = examples/simple examples/normalize examples/simple_error examples/normalize_error examples/fingerprint
+EXAMPLES = examples/simple examples/normalize examples/simple_error examples/normalize_error
+TESTS = test/fingerprint
 
 pg_query_fingerprint.o: pg_query_fingerprint.c pg_query_fingerprint_defs.c pg_query_fingerprint_conds.c
 pg_query_json.o: pg_query_json.c pg_query_json_defs.c pg_query_json_conds.c
@@ -121,7 +122,6 @@ examples: $(EXAMPLES)
 	examples/normalize
 	examples/simple_error
 	examples/normalize_error
-	examples/fingerprint
 
 examples/simple: examples/simple.c $(ARLIB)
 	$(CC) -I. -L. -o $@ -g examples/simple.c $(ARLIB)
@@ -135,5 +135,8 @@ examples/simple_error: examples/simple_error.c $(ARLIB)
 examples/normalize_error: examples/normalize_error.c $(ARLIB)
 	$(CC) -I. -L. -o $@ -g examples/normalize_error.c $(ARLIB)
 
-examples/fingerprint: examples/fingerprint.c $(ARLIB)
-	$(CC) -I. -L. -o $@ -g examples/fingerprint.c $(ARLIB)
+test: $(TESTS)
+	test/fingerprint
+
+test/fingerprint: test/fingerprint.c test/fingerprint_tests.c $(ARLIB)
+	$(CC) -I. -L. -o $@ -g test/fingerprint.c $(ARLIB)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Due to compiling parts of PostgreSQL, running `make` will take a while. Expect u
 For a production build, its best to use `make DEBUG=0` and use a specific git tag (see CHANGELOG).
 
 
-## Usage
+## Usage: Parsing a query
 
 A [full example](https://github.com/lfittl/libpg_query/blob/master/examples/simple.c) that parses a query looks like this:
 
@@ -54,6 +54,40 @@ This will output:
 ```
 [{"SELECT": {"distinctClause": null, "intoClause": null, "targetList": [{"RESTARGET": {"name": null, "indirection": null, "val": {"A_CONST": {"val": 1, "location": 7}}, "location": 7}}], "fromClause": null, "whereClause": null, "groupClause": null, "havingClause": null, "windowClause": null, "valuesLists": null, "sortClause": null, "limitOffset": null, "limitCount": null, "lockingClause": null, "withClause": null, "op": 0, "all": false, "larg": null, "rarg": null}}]
 ```
+
+
+## Usage: Fingerprinting a query
+
+Fingerprinting allows you to identify similar queries that are different only because
+of the specific object that is being queried for (i.e. different object ids in the WHERE clause),
+or because of formatting.
+
+Example:
+
+```
+#include <pg_query.h>
+#include <stdio.h>
+
+int main() {
+  PgQueryFingerprintResult result;
+
+  pg_query_init();
+
+  result = pg_query_fingerprint("SELECT 1");
+
+  printf("%s\n", result.hexdigest);
+
+  pg_query_free_fingerprint_result(result);
+}
+```
+
+This will output:
+
+```
+8e1acac181c6d28f4a923392cf1c4eda49ee4cd2
+```
+
+See https://github.com/lfittl/libpg_query/wiki/Fingerprinting for the full fingerprinting rules.
 
 
 ## Versions

--- a/examples/fingerprint.c
+++ b/examples/fingerprint.c
@@ -1,0 +1,95 @@
+#include <pg_query.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+size_t testCount = 62;
+
+const char* tests[] = {
+  "SELECT 1",
+  "8e1acac181c6d28f4a923392cf1c4eda49ee4cd2",
+  "SELECT 2",
+  "8e1acac181c6d28f4a923392cf1c4eda49ee4cd2",
+  "SELECT ?",
+  "8e1acac181c6d28f4a923392cf1c4eda49ee4cd2",
+  "SELECT 1; SELECT a FROM b",
+  "c8ff78820feae5ed6d7ca580c598f51e25aa2dbe",
+  "SELECT COUNT(DISTINCT id), * FROM targets WHERE something IS NOT NULL AND elsewhere::interval < now()",
+  "fbfa0619cd50c64ab1301830e8f3f55d6f1c81ff",
+  "INSERT INTO test (a, b) VALUES (?, ?)",
+  "7987d8bb26ed399b481728a6e8ca1b668f13d93e",
+  "INSERT INTO test (b, a) VALUES (?, ?)",
+  "7987d8bb26ed399b481728a6e8ca1b668f13d93e",
+  "SELECT b AS x, a AS y FROM z",
+  "b3a90446a1b17d7e89f211c28e791f45da72ca8b",
+  "SELECT * FROM x WHERE y IN (?)",
+  "68d00e0f1420c03fa1600ddf49455e068f6185c4",
+  "SELECT * FROM x WHERE y IN (?, ?, ?)",
+  "68d00e0f1420c03fa1600ddf49455e068f6185c4",
+  "SELECT * FROM x WHERE y IN ( ?::uuid )",
+  "949ab5b077dc2025b9bfc537fdcd678e42d042fd",
+  "SELECT * FROM x WHERE y IN ( ?::uuid, ?::uuid, ?::uuid )",
+  "949ab5b077dc2025b9bfc537fdcd678e42d042fd",
+  "PREPARE a123 AS SELECT a",
+  "0fd9ef315fb2409090b1c6457e3ff581018d3bed",
+  "EXECUTE a123",
+  "a936fb821c81d405a6834bd3a9ece412d2f8ce99",
+  "DEALLOCATE a123",
+  "387f1c2286cffa102e46dfc1b866e18ffc8c421f",
+  "DEALLOCATE ALL",
+  "387f1c2286cffa102e46dfc1b866e18ffc8c421f",
+  "EXPLAIN ANALYZE SELECT a",
+  "315ff6b68acdf887c8196fd2cb9ee7be506adf36",
+  "WITH a AS (SELECT * FROM x WHERE x.y = ? AND x.z = 1) SELECT * FROM a",
+  "fcf2500b7dcb8b030f3f00cb7c4f2dafd0dbca1c",
+  "CREATE TABLE types (a float(2), b float(49), c NUMERIC(2, 3), d character(4), e char(5), f varchar(6), g character varying(7))",
+  "8b9c10a0987ccba4f8d8263f3fa7e9e8095d6c58",
+  "CREATE VIEW view_a (a, b) AS WITH RECURSIVE view_a (a, b) AS (SELECT * FROM a(1)) SELECT \"a\", \"b\" FROM \"view_a\"",
+  "c1164d94a613858d257352dc6b7d3998d23cc27e",
+  "VACUUM FULL my_table",
+  "764cba2fdeb69c2136c4450280456af1cb0065d5",
+  "SELECT * FROM x AS a, y AS b",
+  "449b0e33058c2020cb901507428371e76dd1135c",
+  "SELECT * FROM y AS a, x AS b",
+  "449b0e33058c2020cb901507428371e76dd1135c",
+  "SELECT x AS a, y AS b FROM x",
+  "dff6cdb02bb700f67eb86d53a66fe5a527c04a5b",
+  "SELECT y AS a, x AS b FROM x",
+  "dff6cdb02bb700f67eb86d53a66fe5a527c04a5b",
+  "SELECT x, y FROM z",
+  "67ab69242d6b9daf09ea4e1ab11b0b90b53a2b15",
+  "SELECT y, x FROM z",
+  "67ab69242d6b9daf09ea4e1ab11b0b90b53a2b15",
+  "INSERT INTO films (code, title, did) VALUES ('UA502', 'Bananas', 105), ('T_601', 'Yojimbo', DEFAULT)",
+  "8658f8f49178096f7dd87f81ed184208efe7ed56",
+  "INSERT INTO films (code, title, did) VALUES (?, ?, ?)",
+  "8658f8f49178096f7dd87f81ed184208efe7ed56",
+  "SELECT * FROM a",
+  "1f3a0a714c4e3bbf38e9eab45104fe96f7746ab2",
+  "SELECT * FROM a AS b",
+  "1f3a0a714c4e3bbf38e9eab45104fe96f7746ab2",
+};
+
+int main() {
+  size_t i;
+
+  pg_query_init();
+
+  for (i = 0; i < testCount; i += 2) {
+    PgQueryFingerprintResult result = pg_query_fingerprint(tests[i]);
+
+    if (strcmp(result.hexdigest, tests[i + 1]) == 0) {
+      printf(".");
+    } else {
+      printf("INVALID (%s needs to be %s, SQL was: %s)\n", result.hexdigest, tests[i + 1], tests[i]);
+      pg_query_fingerprint_with_opts(tests[i], true);
+    }
+
+    pg_query_free_fingerprint_result(result);
+  }
+
+  printf("\n");
+
+  return 0;
+}

--- a/pg_query.h
+++ b/pg_query.h
@@ -1,6 +1,8 @@
 #ifndef PG_QUERY_H
 #define PG_QUERY_H
 
+#include <stdbool.h>
+
 typedef struct {
 	char* message; // exception message
 	char* filename; // source of exception (e.g. parse.l)
@@ -13,6 +15,12 @@ typedef struct {
   char* stderr_buffer;
   PgQueryError* error;
 } PgQueryParseResult;
+
+typedef struct {
+  char* hexdigest;
+  char* stderr_buffer;
+  PgQueryError* error;
+} PgQueryFingerprintResult;
 
 typedef struct {
   char* normalized_query;
@@ -28,6 +36,10 @@ PgQueryNormalizeResult pg_query_normalize(const char* input);
 PgQueryParseResult pg_query_parse(const char* input);
 void pg_query_free_normalize_result(PgQueryNormalizeResult result);
 void pg_query_free_parse_result(PgQueryParseResult result);
+void pg_query_free_fingerprint_result(PgQueryFingerprintResult result);
+
+PgQueryFingerprintResult pg_query_fingerprint(const char* input);
+PgQueryFingerprintResult pg_query_fingerprint_with_opts(const char* input, bool printTokens);
 
 #ifdef __cplusplus
 }

--- a/pg_query_fingerprint.c
+++ b/pg_query_fingerprint.c
@@ -1,0 +1,314 @@
+#include "pg_query.h"
+#include "pg_query_internal.h"
+
+#include "postgres.h"
+#include "sha1.h"
+#include "lib/ilist.h"
+
+#include "parser/parser.h"
+#include "parser/scanner.h"
+#include "parser/scansup.h"
+
+#include "nodes/parsenodes.h"
+#include "nodes/value.h"
+
+#include <unistd.h>
+#include <fcntl.h>
+
+// Definitions
+
+typedef struct FingerprintContext
+{
+  dlist_head tokens;
+  SHA1_CTX *sha1; // If this is NULL we write tokens, otherwise we write the sha1sum directly
+} FingerprintContext;
+
+typedef struct FingerprintToken
+{
+  char *str;
+  dlist_node list_node;
+} FingerprintToken;
+
+static void _fingerprintNode(FingerprintContext *ctx, const void *obj, char *parent_field_name);
+static void _fingerprintInitForTokens(FingerprintContext *ctx);
+static void _fingerprintCopyTokens(FingerprintContext *source, FingerprintContext *target, char *field_name);
+
+// Implementations
+
+static void
+_fingerprintString(FingerprintContext *ctx, const char *str)
+{
+  if (ctx->sha1 != NULL) {
+    SHA1Update(ctx->sha1, (uint8*) str, strlen(str));
+  } else {
+    FingerprintToken *token = palloc0(sizeof(FingerprintToken));
+    token->str = pstrdup(str);
+    dlist_push_tail(&ctx->tokens, &token->list_node);
+  }
+}
+
+static void
+_fingerprintInteger(FingerprintContext *ctx, const Value *node)
+{
+  if (node->val.ival != 0) {
+    _fingerprintString(ctx, "Integer");
+    _fingerprintString(ctx, "ival");
+    char buffer[50];
+    sprintf(buffer, "%ld", node->val.ival);
+    _fingerprintString(ctx, buffer);
+  }
+}
+
+static void
+_fingerprintFloat(FingerprintContext *ctx, const Value *node)
+{
+  if (node->val.str != NULL) {
+    _fingerprintString(ctx, "Float");
+    _fingerprintString(ctx, "str");
+    _fingerprintString(ctx, node->val.str);
+  }
+}
+
+static void
+_fingerprintBitString(FingerprintContext *ctx, const Value *node)
+{
+  if (node->val.str != NULL) {
+    _fingerprintString(ctx, "BitString");
+    _fingerprintString(ctx, "str");
+    _fingerprintString(ctx, node->val.str);
+  }
+}
+
+#define FINGERPRINT_CMP_STRBUF 1024
+
+static int compareFingerprintContext(const void *a, const void *b)
+{
+  FingerprintContext *ca = *(FingerprintContext**) a;
+  FingerprintContext *cb = *(FingerprintContext**) b;
+
+  char strBufA[FINGERPRINT_CMP_STRBUF + 1] = {'\0'};
+  char strBufB[FINGERPRINT_CMP_STRBUF + 1] = {'\0'};
+
+  dlist_iter iterA;
+  dlist_iter iterB;
+
+  dlist_foreach(iterA, &ca->tokens)
+  {
+    FingerprintToken *token = dlist_container(FingerprintToken, list_node, iterA.cur);
+
+    strncat(strBufA, token->str, FINGERPRINT_CMP_STRBUF - strlen(strBufA));
+  }
+
+  dlist_foreach(iterB, &cb->tokens)
+  {
+    FingerprintToken *token = dlist_container(FingerprintToken, list_node, iterB.cur);
+
+    strncat(strBufB, token->str, FINGERPRINT_CMP_STRBUF - strlen(strBufB));
+  }
+
+  //printf("COMP %s <=> %s = %d\n", strBufA, strBufB, strcmp(strBufA, strBufB));
+
+  return strcmp(strBufA, strBufB);
+}
+
+static void
+_fingerprintList(FingerprintContext *ctx, const List *node, char *field_name)
+{
+  if (field_name != NULL && (strcmp(field_name, "fromClause") == 0 || strcmp(field_name, "targetList") == 0 ||
+      strcmp(field_name, "cols") == 0 || strcmp(field_name, "rexpr") == 0)) {
+
+    FingerprintContext** subCtxArr = palloc0(node->length * sizeof(FingerprintContext*));
+    size_t subCtxCount = 0;
+    size_t i;
+    const ListCell *lc;
+
+    foreach(lc, node)
+  	{
+      FingerprintContext* subCtx = palloc0(sizeof(FingerprintContext));
+
+      _fingerprintInitForTokens(subCtx);
+  		_fingerprintNode(subCtx, lfirst(lc), field_name);
+
+      bool exists = false;
+      for (i = 0; i < subCtxCount; i++) {
+        if (compareFingerprintContext(&subCtxArr[i], &subCtx) == 0) {
+          exists = true;
+          break;
+        }
+      }
+
+      if (!exists) {
+        subCtxArr[subCtxCount] = subCtx;
+        subCtxCount += 1;
+      }
+
+  		lnext(lc);
+  	}
+
+    pg_qsort(subCtxArr, subCtxCount, sizeof(FingerprintContext*), compareFingerprintContext);
+
+    for (i = 0; i < subCtxCount; i++) {
+      _fingerprintCopyTokens(subCtxArr[i], ctx, NULL);
+    }
+	} else {
+    const ListCell *lc;
+
+    foreach(lc, node)
+  	{
+  		_fingerprintNode(ctx, lfirst(lc), field_name);
+
+  		lnext(lc);
+  	}
+  }
+}
+
+static void
+_fingerprintInitForTokens(FingerprintContext *ctx) {
+  ctx->sha1 = NULL;
+  dlist_init(&ctx->tokens);
+}
+
+static void
+_fingerprintCopyTokens(FingerprintContext *source, FingerprintContext *target, char *field_name) {
+  dlist_iter iter;
+
+  if (dlist_is_empty(&source->tokens)) return;
+
+  if (field_name != NULL) {
+    _fingerprintString(target, field_name);
+  }
+
+  dlist_foreach(iter, &source->tokens)
+  {
+    FingerprintToken *token = dlist_container(FingerprintToken, list_node, iter.cur);
+
+    _fingerprintString(target, token->str);
+  }
+}
+
+#include "pg_query_fingerprint_defs.c"
+
+void
+_fingerprintNode(FingerprintContext *ctx, const void *obj, char *field_name)
+{
+	if (obj == NULL)
+	{
+		return; // Ignore
+	}
+
+	if (IsA(obj, List))
+	{
+		_fingerprintList(ctx, obj, field_name);
+	}
+	else
+	{
+		switch (nodeTag(obj))
+		{
+			case T_Integer:
+				_fingerprintInteger(ctx, obj);
+				break;
+			case T_Float:
+				_fingerprintFloat(ctx, obj);
+				break;
+			case T_String:
+        _fingerprintString(ctx, "String");
+        _fingerprintString(ctx, "str");
+				_fingerprintString(ctx, ((Value*) obj)->val.str);
+				break;
+			case T_BitString:
+				_fingerprintBitString(ctx, obj);
+				break;
+			case T_Null:
+				return; // Ignore
+			case T_IntList:
+				//_fingerprintIntList(ctx, obj); // FIXME
+				break;
+			case T_OidList:
+				//_fingerprintOidList(ctx, obj); // FIXME
+				break;
+
+			#include "pg_query_fingerprint_conds.c"
+
+			default:
+				elog(WARNING, "could not fingerprint unrecognized node type: %d",
+					 (int) nodeTag(obj));
+
+				return;
+		}
+	}
+}
+
+PgQueryFingerprintResult pg_query_fingerprint_with_opts(const char* input, bool printTokens)
+{
+	MemoryContext ctx = NULL;
+	PgQueryInternalParsetreeAndError parsetree_and_error;
+	PgQueryFingerprintResult result = {0};
+
+	ctx = pg_query_enter_memory_context("pg_query_fingerprint");
+
+	parsetree_and_error = pg_query_raw_parse(input);
+
+  // These are all malloc-ed and will survive exiting the memory context, the caller is responsible to free them now
+  result.stderr_buffer = parsetree_and_error.stderr_buffer;
+  result.error = parsetree_and_error.error;
+
+	if (parsetree_and_error.tree != NULL) {
+    FingerprintContext ctx;
+    int i;
+    uint8 sha1result[SHA1_RESULTLEN];
+
+    ctx.sha1 = palloc0(sizeof(SHA1_CTX));
+    SHA1Init(ctx.sha1);
+
+    _fingerprintNode(&ctx, parsetree_and_error.tree, NULL);
+
+    SHA1Final(sha1result, ctx.sha1);
+
+    // This is intentionally malloc-ed and will survive exiting the memory context
+    result.hexdigest = calloc(41, sizeof(char));
+
+    for (i = 0; i < SHA1_RESULTLEN; i++) {
+      sprintf(result.hexdigest + i * 2, "%02x", sha1result[i]);
+    }
+
+    if (printTokens) {
+      FingerprintContext debugCtx;
+      dlist_iter iter;
+
+      _fingerprintInitForTokens(&debugCtx);
+      _fingerprintNode(&debugCtx, parsetree_and_error.tree, NULL);
+
+      printf("[");
+
+      dlist_foreach(iter, &debugCtx.tokens)
+      {
+        FingerprintToken *token = dlist_container(FingerprintToken, list_node, iter.cur);
+
+        printf("%s, ", token->str);
+      }
+
+      printf("]\n");
+    }
+	}
+
+	pg_query_exit_memory_context(ctx);
+
+	return result;
+}
+
+PgQueryFingerprintResult pg_query_fingerprint(const char* input)
+{
+  return pg_query_fingerprint_with_opts(input, false);
+}
+
+void pg_query_free_fingerprint_result(PgQueryFingerprintResult result)
+{
+  if (result.error) {
+    free(result.error->message);
+    free(result.error->filename);
+    free(result.error);
+  }
+
+  free(result.hexdigest);
+  free(result.stderr_buffer);
+}

--- a/pg_query_fingerprint_conds.c
+++ b/pg_query_fingerprint_conds.c
@@ -1,0 +1,576 @@
+case T_Alias:
+  _fingerprintAlias(ctx, obj, field_name);
+  break;
+case T_RangeVar:
+  _fingerprintRangeVar(ctx, obj, field_name);
+  break;
+case T_Expr:
+  _fingerprintExpr(ctx, obj, field_name);
+  break;
+case T_Var:
+  _fingerprintVar(ctx, obj, field_name);
+  break;
+case T_Const:
+  _fingerprintConst(ctx, obj, field_name);
+  break;
+case T_Param:
+  _fingerprintParam(ctx, obj, field_name);
+  break;
+case T_Aggref:
+  _fingerprintAggref(ctx, obj, field_name);
+  break;
+case T_GroupingFunc:
+  _fingerprintGroupingFunc(ctx, obj, field_name);
+  break;
+case T_WindowFunc:
+  _fingerprintWindowFunc(ctx, obj, field_name);
+  break;
+case T_ArrayRef:
+  _fingerprintArrayRef(ctx, obj, field_name);
+  break;
+case T_FuncExpr:
+  _fingerprintFuncExpr(ctx, obj, field_name);
+  break;
+case T_NamedArgExpr:
+  _fingerprintNamedArgExpr(ctx, obj, field_name);
+  break;
+case T_OpExpr:
+  _fingerprintOpExpr(ctx, obj, field_name);
+  break;
+case T_ScalarArrayOpExpr:
+  _fingerprintScalarArrayOpExpr(ctx, obj, field_name);
+  break;
+case T_BoolExpr:
+  _fingerprintBoolExpr(ctx, obj, field_name);
+  break;
+case T_SubLink:
+  _fingerprintSubLink(ctx, obj, field_name);
+  break;
+case T_SubPlan:
+  _fingerprintSubPlan(ctx, obj, field_name);
+  break;
+case T_AlternativeSubPlan:
+  _fingerprintAlternativeSubPlan(ctx, obj, field_name);
+  break;
+case T_FieldSelect:
+  _fingerprintFieldSelect(ctx, obj, field_name);
+  break;
+case T_FieldStore:
+  _fingerprintFieldStore(ctx, obj, field_name);
+  break;
+case T_RelabelType:
+  _fingerprintRelabelType(ctx, obj, field_name);
+  break;
+case T_CoerceViaIO:
+  _fingerprintCoerceViaIO(ctx, obj, field_name);
+  break;
+case T_ArrayCoerceExpr:
+  _fingerprintArrayCoerceExpr(ctx, obj, field_name);
+  break;
+case T_ConvertRowtypeExpr:
+  _fingerprintConvertRowtypeExpr(ctx, obj, field_name);
+  break;
+case T_CollateExpr:
+  _fingerprintCollateExpr(ctx, obj, field_name);
+  break;
+case T_CaseExpr:
+  _fingerprintCaseExpr(ctx, obj, field_name);
+  break;
+case T_CaseWhen:
+  _fingerprintCaseWhen(ctx, obj, field_name);
+  break;
+case T_CaseTestExpr:
+  _fingerprintCaseTestExpr(ctx, obj, field_name);
+  break;
+case T_ArrayExpr:
+  _fingerprintArrayExpr(ctx, obj, field_name);
+  break;
+case T_RowExpr:
+  _fingerprintRowExpr(ctx, obj, field_name);
+  break;
+case T_RowCompareExpr:
+  _fingerprintRowCompareExpr(ctx, obj, field_name);
+  break;
+case T_CoalesceExpr:
+  _fingerprintCoalesceExpr(ctx, obj, field_name);
+  break;
+case T_MinMaxExpr:
+  _fingerprintMinMaxExpr(ctx, obj, field_name);
+  break;
+case T_XmlExpr:
+  _fingerprintXmlExpr(ctx, obj, field_name);
+  break;
+case T_NullTest:
+  _fingerprintNullTest(ctx, obj, field_name);
+  break;
+case T_BooleanTest:
+  _fingerprintBooleanTest(ctx, obj, field_name);
+  break;
+case T_CoerceToDomain:
+  _fingerprintCoerceToDomain(ctx, obj, field_name);
+  break;
+case T_CoerceToDomainValue:
+  _fingerprintCoerceToDomainValue(ctx, obj, field_name);
+  break;
+case T_SetToDefault:
+  _fingerprintSetToDefault(ctx, obj, field_name);
+  break;
+case T_CurrentOfExpr:
+  _fingerprintCurrentOfExpr(ctx, obj, field_name);
+  break;
+case T_InferenceElem:
+  _fingerprintInferenceElem(ctx, obj, field_name);
+  break;
+case T_TargetEntry:
+  _fingerprintTargetEntry(ctx, obj, field_name);
+  break;
+case T_RangeTblRef:
+  _fingerprintRangeTblRef(ctx, obj, field_name);
+  break;
+case T_JoinExpr:
+  _fingerprintJoinExpr(ctx, obj, field_name);
+  break;
+case T_FromExpr:
+  _fingerprintFromExpr(ctx, obj, field_name);
+  break;
+case T_OnConflictExpr:
+  _fingerprintOnConflictExpr(ctx, obj, field_name);
+  break;
+case T_IntoClause:
+  _fingerprintIntoClause(ctx, obj, field_name);
+  break;
+case T_Query:
+  _fingerprintQuery(ctx, obj, field_name);
+  break;
+case T_InsertStmt:
+  _fingerprintInsertStmt(ctx, obj, field_name);
+  break;
+case T_DeleteStmt:
+  _fingerprintDeleteStmt(ctx, obj, field_name);
+  break;
+case T_UpdateStmt:
+  _fingerprintUpdateStmt(ctx, obj, field_name);
+  break;
+case T_SelectStmt:
+  _fingerprintSelectStmt(ctx, obj, field_name);
+  break;
+case T_AlterTableStmt:
+  _fingerprintAlterTableStmt(ctx, obj, field_name);
+  break;
+case T_AlterTableCmd:
+  _fingerprintAlterTableCmd(ctx, obj, field_name);
+  break;
+case T_AlterDomainStmt:
+  _fingerprintAlterDomainStmt(ctx, obj, field_name);
+  break;
+case T_SetOperationStmt:
+  _fingerprintSetOperationStmt(ctx, obj, field_name);
+  break;
+case T_GrantStmt:
+  _fingerprintGrantStmt(ctx, obj, field_name);
+  break;
+case T_GrantRoleStmt:
+  _fingerprintGrantRoleStmt(ctx, obj, field_name);
+  break;
+case T_AlterDefaultPrivilegesStmt:
+  _fingerprintAlterDefaultPrivilegesStmt(ctx, obj, field_name);
+  break;
+case T_ClosePortalStmt:
+  _fingerprintClosePortalStmt(ctx, obj, field_name);
+  break;
+case T_ClusterStmt:
+  _fingerprintClusterStmt(ctx, obj, field_name);
+  break;
+case T_CopyStmt:
+  _fingerprintCopyStmt(ctx, obj, field_name);
+  break;
+case T_CreateStmt:
+  _fingerprintCreateStmt(ctx, obj, field_name);
+  break;
+case T_DefineStmt:
+  _fingerprintDefineStmt(ctx, obj, field_name);
+  break;
+case T_DropStmt:
+  _fingerprintDropStmt(ctx, obj, field_name);
+  break;
+case T_TruncateStmt:
+  _fingerprintTruncateStmt(ctx, obj, field_name);
+  break;
+case T_CommentStmt:
+  _fingerprintCommentStmt(ctx, obj, field_name);
+  break;
+case T_FetchStmt:
+  _fingerprintFetchStmt(ctx, obj, field_name);
+  break;
+case T_IndexStmt:
+  _fingerprintIndexStmt(ctx, obj, field_name);
+  break;
+case T_CreateFunctionStmt:
+  _fingerprintCreateFunctionStmt(ctx, obj, field_name);
+  break;
+case T_AlterFunctionStmt:
+  _fingerprintAlterFunctionStmt(ctx, obj, field_name);
+  break;
+case T_DoStmt:
+  _fingerprintDoStmt(ctx, obj, field_name);
+  break;
+case T_RenameStmt:
+  _fingerprintRenameStmt(ctx, obj, field_name);
+  break;
+case T_RuleStmt:
+  _fingerprintRuleStmt(ctx, obj, field_name);
+  break;
+case T_NotifyStmt:
+  _fingerprintNotifyStmt(ctx, obj, field_name);
+  break;
+case T_ListenStmt:
+  _fingerprintListenStmt(ctx, obj, field_name);
+  break;
+case T_UnlistenStmt:
+  _fingerprintUnlistenStmt(ctx, obj, field_name);
+  break;
+case T_TransactionStmt:
+  _fingerprintTransactionStmt(ctx, obj, field_name);
+  break;
+case T_ViewStmt:
+  _fingerprintViewStmt(ctx, obj, field_name);
+  break;
+case T_LoadStmt:
+  _fingerprintLoadStmt(ctx, obj, field_name);
+  break;
+case T_CreateDomainStmt:
+  _fingerprintCreateDomainStmt(ctx, obj, field_name);
+  break;
+case T_CreatedbStmt:
+  _fingerprintCreatedbStmt(ctx, obj, field_name);
+  break;
+case T_DropdbStmt:
+  _fingerprintDropdbStmt(ctx, obj, field_name);
+  break;
+case T_VacuumStmt:
+  _fingerprintVacuumStmt(ctx, obj, field_name);
+  break;
+case T_ExplainStmt:
+  _fingerprintExplainStmt(ctx, obj, field_name);
+  break;
+case T_CreateTableAsStmt:
+  _fingerprintCreateTableAsStmt(ctx, obj, field_name);
+  break;
+case T_CreateSeqStmt:
+  _fingerprintCreateSeqStmt(ctx, obj, field_name);
+  break;
+case T_AlterSeqStmt:
+  _fingerprintAlterSeqStmt(ctx, obj, field_name);
+  break;
+case T_VariableSetStmt:
+  _fingerprintVariableSetStmt(ctx, obj, field_name);
+  break;
+case T_VariableShowStmt:
+  _fingerprintVariableShowStmt(ctx, obj, field_name);
+  break;
+case T_DiscardStmt:
+  _fingerprintDiscardStmt(ctx, obj, field_name);
+  break;
+case T_CreateTrigStmt:
+  _fingerprintCreateTrigStmt(ctx, obj, field_name);
+  break;
+case T_CreatePLangStmt:
+  _fingerprintCreatePLangStmt(ctx, obj, field_name);
+  break;
+case T_CreateRoleStmt:
+  _fingerprintCreateRoleStmt(ctx, obj, field_name);
+  break;
+case T_AlterRoleStmt:
+  _fingerprintAlterRoleStmt(ctx, obj, field_name);
+  break;
+case T_DropRoleStmt:
+  _fingerprintDropRoleStmt(ctx, obj, field_name);
+  break;
+case T_LockStmt:
+  _fingerprintLockStmt(ctx, obj, field_name);
+  break;
+case T_ConstraintsSetStmt:
+  _fingerprintConstraintsSetStmt(ctx, obj, field_name);
+  break;
+case T_ReindexStmt:
+  _fingerprintReindexStmt(ctx, obj, field_name);
+  break;
+case T_CheckPointStmt:
+  _fingerprintCheckPointStmt(ctx, obj, field_name);
+  break;
+case T_CreateSchemaStmt:
+  _fingerprintCreateSchemaStmt(ctx, obj, field_name);
+  break;
+case T_AlterDatabaseStmt:
+  _fingerprintAlterDatabaseStmt(ctx, obj, field_name);
+  break;
+case T_AlterDatabaseSetStmt:
+  _fingerprintAlterDatabaseSetStmt(ctx, obj, field_name);
+  break;
+case T_AlterRoleSetStmt:
+  _fingerprintAlterRoleSetStmt(ctx, obj, field_name);
+  break;
+case T_CreateConversionStmt:
+  _fingerprintCreateConversionStmt(ctx, obj, field_name);
+  break;
+case T_CreateCastStmt:
+  _fingerprintCreateCastStmt(ctx, obj, field_name);
+  break;
+case T_CreateOpClassStmt:
+  _fingerprintCreateOpClassStmt(ctx, obj, field_name);
+  break;
+case T_CreateOpFamilyStmt:
+  _fingerprintCreateOpFamilyStmt(ctx, obj, field_name);
+  break;
+case T_AlterOpFamilyStmt:
+  _fingerprintAlterOpFamilyStmt(ctx, obj, field_name);
+  break;
+case T_PrepareStmt:
+  _fingerprintPrepareStmt(ctx, obj, field_name);
+  break;
+case T_ExecuteStmt:
+  _fingerprintExecuteStmt(ctx, obj, field_name);
+  break;
+case T_DeallocateStmt:
+  _fingerprintDeallocateStmt(ctx, obj, field_name);
+  break;
+case T_DeclareCursorStmt:
+  _fingerprintDeclareCursorStmt(ctx, obj, field_name);
+  break;
+case T_CreateTableSpaceStmt:
+  _fingerprintCreateTableSpaceStmt(ctx, obj, field_name);
+  break;
+case T_DropTableSpaceStmt:
+  _fingerprintDropTableSpaceStmt(ctx, obj, field_name);
+  break;
+case T_AlterObjectSchemaStmt:
+  _fingerprintAlterObjectSchemaStmt(ctx, obj, field_name);
+  break;
+case T_AlterOwnerStmt:
+  _fingerprintAlterOwnerStmt(ctx, obj, field_name);
+  break;
+case T_DropOwnedStmt:
+  _fingerprintDropOwnedStmt(ctx, obj, field_name);
+  break;
+case T_ReassignOwnedStmt:
+  _fingerprintReassignOwnedStmt(ctx, obj, field_name);
+  break;
+case T_CompositeTypeStmt:
+  _fingerprintCompositeTypeStmt(ctx, obj, field_name);
+  break;
+case T_CreateEnumStmt:
+  _fingerprintCreateEnumStmt(ctx, obj, field_name);
+  break;
+case T_CreateRangeStmt:
+  _fingerprintCreateRangeStmt(ctx, obj, field_name);
+  break;
+case T_AlterEnumStmt:
+  _fingerprintAlterEnumStmt(ctx, obj, field_name);
+  break;
+case T_AlterTSDictionaryStmt:
+  _fingerprintAlterTSDictionaryStmt(ctx, obj, field_name);
+  break;
+case T_AlterTSConfigurationStmt:
+  _fingerprintAlterTSConfigurationStmt(ctx, obj, field_name);
+  break;
+case T_CreateFdwStmt:
+  _fingerprintCreateFdwStmt(ctx, obj, field_name);
+  break;
+case T_AlterFdwStmt:
+  _fingerprintAlterFdwStmt(ctx, obj, field_name);
+  break;
+case T_CreateForeignServerStmt:
+  _fingerprintCreateForeignServerStmt(ctx, obj, field_name);
+  break;
+case T_AlterForeignServerStmt:
+  _fingerprintAlterForeignServerStmt(ctx, obj, field_name);
+  break;
+case T_CreateUserMappingStmt:
+  _fingerprintCreateUserMappingStmt(ctx, obj, field_name);
+  break;
+case T_AlterUserMappingStmt:
+  _fingerprintAlterUserMappingStmt(ctx, obj, field_name);
+  break;
+case T_DropUserMappingStmt:
+  _fingerprintDropUserMappingStmt(ctx, obj, field_name);
+  break;
+case T_AlterTableSpaceOptionsStmt:
+  _fingerprintAlterTableSpaceOptionsStmt(ctx, obj, field_name);
+  break;
+case T_AlterTableMoveAllStmt:
+  _fingerprintAlterTableMoveAllStmt(ctx, obj, field_name);
+  break;
+case T_SecLabelStmt:
+  _fingerprintSecLabelStmt(ctx, obj, field_name);
+  break;
+case T_CreateForeignTableStmt:
+  _fingerprintCreateForeignTableStmt(ctx, obj, field_name);
+  break;
+case T_ImportForeignSchemaStmt:
+  _fingerprintImportForeignSchemaStmt(ctx, obj, field_name);
+  break;
+case T_CreateExtensionStmt:
+  _fingerprintCreateExtensionStmt(ctx, obj, field_name);
+  break;
+case T_AlterExtensionStmt:
+  _fingerprintAlterExtensionStmt(ctx, obj, field_name);
+  break;
+case T_AlterExtensionContentsStmt:
+  _fingerprintAlterExtensionContentsStmt(ctx, obj, field_name);
+  break;
+case T_CreateEventTrigStmt:
+  _fingerprintCreateEventTrigStmt(ctx, obj, field_name);
+  break;
+case T_AlterEventTrigStmt:
+  _fingerprintAlterEventTrigStmt(ctx, obj, field_name);
+  break;
+case T_RefreshMatViewStmt:
+  _fingerprintRefreshMatViewStmt(ctx, obj, field_name);
+  break;
+case T_ReplicaIdentityStmt:
+  _fingerprintReplicaIdentityStmt(ctx, obj, field_name);
+  break;
+case T_AlterSystemStmt:
+  _fingerprintAlterSystemStmt(ctx, obj, field_name);
+  break;
+case T_CreatePolicyStmt:
+  _fingerprintCreatePolicyStmt(ctx, obj, field_name);
+  break;
+case T_AlterPolicyStmt:
+  _fingerprintAlterPolicyStmt(ctx, obj, field_name);
+  break;
+case T_CreateTransformStmt:
+  _fingerprintCreateTransformStmt(ctx, obj, field_name);
+  break;
+case T_A_Expr:
+  _fingerprintA_Expr(ctx, obj, field_name);
+  break;
+case T_ColumnRef:
+  _fingerprintColumnRef(ctx, obj, field_name);
+  break;
+case T_ParamRef:
+  _fingerprintParamRef(ctx, obj, field_name);
+  break;
+case T_A_Const:
+  _fingerprintA_Const(ctx, obj, field_name);
+  break;
+case T_FuncCall:
+  _fingerprintFuncCall(ctx, obj, field_name);
+  break;
+case T_A_Star:
+  _fingerprintA_Star(ctx, obj, field_name);
+  break;
+case T_A_Indices:
+  _fingerprintA_Indices(ctx, obj, field_name);
+  break;
+case T_A_Indirection:
+  _fingerprintA_Indirection(ctx, obj, field_name);
+  break;
+case T_A_ArrayExpr:
+  _fingerprintA_ArrayExpr(ctx, obj, field_name);
+  break;
+case T_ResTarget:
+  _fingerprintResTarget(ctx, obj, field_name);
+  break;
+case T_MultiAssignRef:
+  _fingerprintMultiAssignRef(ctx, obj, field_name);
+  break;
+case T_TypeCast:
+  _fingerprintTypeCast(ctx, obj, field_name);
+  break;
+case T_CollateClause:
+  _fingerprintCollateClause(ctx, obj, field_name);
+  break;
+case T_SortBy:
+  _fingerprintSortBy(ctx, obj, field_name);
+  break;
+case T_WindowDef:
+  _fingerprintWindowDef(ctx, obj, field_name);
+  break;
+case T_RangeSubselect:
+  _fingerprintRangeSubselect(ctx, obj, field_name);
+  break;
+case T_RangeFunction:
+  _fingerprintRangeFunction(ctx, obj, field_name);
+  break;
+case T_RangeTableSample:
+  _fingerprintRangeTableSample(ctx, obj, field_name);
+  break;
+case T_TypeName:
+  _fingerprintTypeName(ctx, obj, field_name);
+  break;
+case T_ColumnDef:
+  _fingerprintColumnDef(ctx, obj, field_name);
+  break;
+case T_IndexElem:
+  _fingerprintIndexElem(ctx, obj, field_name);
+  break;
+case T_Constraint:
+  _fingerprintConstraint(ctx, obj, field_name);
+  break;
+case T_DefElem:
+  _fingerprintDefElem(ctx, obj, field_name);
+  break;
+case T_RangeTblEntry:
+  _fingerprintRangeTblEntry(ctx, obj, field_name);
+  break;
+case T_RangeTblFunction:
+  _fingerprintRangeTblFunction(ctx, obj, field_name);
+  break;
+case T_TableSampleClause:
+  _fingerprintTableSampleClause(ctx, obj, field_name);
+  break;
+case T_WithCheckOption:
+  _fingerprintWithCheckOption(ctx, obj, field_name);
+  break;
+case T_SortGroupClause:
+  _fingerprintSortGroupClause(ctx, obj, field_name);
+  break;
+case T_GroupingSet:
+  _fingerprintGroupingSet(ctx, obj, field_name);
+  break;
+case T_WindowClause:
+  _fingerprintWindowClause(ctx, obj, field_name);
+  break;
+case T_FuncWithArgs:
+  _fingerprintFuncWithArgs(ctx, obj, field_name);
+  break;
+case T_AccessPriv:
+  _fingerprintAccessPriv(ctx, obj, field_name);
+  break;
+case T_CreateOpClassItem:
+  _fingerprintCreateOpClassItem(ctx, obj, field_name);
+  break;
+case T_TableLikeClause:
+  _fingerprintTableLikeClause(ctx, obj, field_name);
+  break;
+case T_FunctionParameter:
+  _fingerprintFunctionParameter(ctx, obj, field_name);
+  break;
+case T_LockingClause:
+  _fingerprintLockingClause(ctx, obj, field_name);
+  break;
+case T_RowMarkClause:
+  _fingerprintRowMarkClause(ctx, obj, field_name);
+  break;
+case T_XmlSerialize:
+  _fingerprintXmlSerialize(ctx, obj, field_name);
+  break;
+case T_WithClause:
+  _fingerprintWithClause(ctx, obj, field_name);
+  break;
+case T_InferClause:
+  _fingerprintInferClause(ctx, obj, field_name);
+  break;
+case T_OnConflictClause:
+  _fingerprintOnConflictClause(ctx, obj, field_name);
+  break;
+case T_CommonTableExpr:
+  _fingerprintCommonTableExpr(ctx, obj, field_name);
+  break;
+case T_RoleSpec:
+  _fingerprintRoleSpec(ctx, obj, field_name);
+  break;
+case T_InlineCodeBlock:
+  _fingerprintInlineCodeBlock(ctx, obj, field_name);
+  break;

--- a/pg_query_fingerprint_defs.c
+++ b/pg_query_fingerprint_defs.c
@@ -1,0 +1,6623 @@
+static void
+_fingerprintAlias(FingerprintContext *ctx, const Alias *node, const char *field_name)
+{
+  // Intentionally ignoring all fields for fingerprinting
+}
+
+static void
+_fingerprintRangeVar(FingerprintContext *ctx, const RangeVar *node, const char *field_name)
+{
+  _fingerprintString(ctx, "RangeVar");
+  if (node->alias != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->alias, "alias");
+    _fingerprintCopyTokens(&subCtx, ctx, "alias");
+  }
+
+  if (node->catalogname != NULL) {
+    _fingerprintString(ctx, "catalogname");
+    _fingerprintString(ctx, node->catalogname);
+  }
+
+  if (node->inhOpt != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->inhOpt);
+    _fingerprintString(ctx, "inhOpt");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+
+  if (node->relname != NULL) {
+    _fingerprintString(ctx, "relname");
+    _fingerprintString(ctx, node->relname);
+  }
+
+  if (node->relpersistence != 0) {
+    char str[2] = {node->relpersistence, '\0'};
+    _fingerprintString(ctx, "relpersistence");
+    _fingerprintString(ctx, str);
+  }
+
+
+  if (node->schemaname != NULL) {
+    _fingerprintString(ctx, "schemaname");
+    _fingerprintString(ctx, node->schemaname);
+  }
+
+}
+
+static void
+_fingerprintExpr(FingerprintContext *ctx, const Expr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "Expr");
+}
+
+static void
+_fingerprintVar(FingerprintContext *ctx, const Var *node, const char *field_name)
+{
+  _fingerprintString(ctx, "Var");
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->varattno != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->varattno);
+    _fingerprintString(ctx, "varattno");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->varcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->varcollid);
+    _fingerprintString(ctx, "varcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->varlevelsup != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->varlevelsup);
+    _fingerprintString(ctx, "varlevelsup");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->varno != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->varno);
+    _fingerprintString(ctx, "varno");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->varnoold != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->varnoold);
+    _fingerprintString(ctx, "varnoold");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->varoattno != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->varoattno);
+    _fingerprintString(ctx, "varoattno");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->vartype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->vartype);
+    _fingerprintString(ctx, "vartype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->vartypmod != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->vartypmod);
+    _fingerprintString(ctx, "vartypmod");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintConst(FingerprintContext *ctx, const Const *node, const char *field_name)
+{
+  _fingerprintString(ctx, "Const");
+
+  if (node->constbyval) {    _fingerprintString(ctx, "constbyval");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->constcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->constcollid);
+    _fingerprintString(ctx, "constcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->constisnull) {    _fingerprintString(ctx, "constisnull");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->constlen != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->constlen);
+    _fingerprintString(ctx, "constlen");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->consttype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->consttype);
+    _fingerprintString(ctx, "consttype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->consttypmod != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->consttypmod);
+    _fingerprintString(ctx, "consttypmod");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+}
+
+static void
+_fingerprintParam(FingerprintContext *ctx, const Param *node, const char *field_name)
+{
+  _fingerprintString(ctx, "Param");
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->paramcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->paramcollid);
+    _fingerprintString(ctx, "paramcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->paramid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->paramid);
+    _fingerprintString(ctx, "paramid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->paramkind != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->paramkind);
+    _fingerprintString(ctx, "paramkind");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->paramtype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->paramtype);
+    _fingerprintString(ctx, "paramtype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->paramtypmod != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->paramtypmod);
+    _fingerprintString(ctx, "paramtypmod");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintAggref(FingerprintContext *ctx, const Aggref *node, const char *field_name)
+{
+  _fingerprintString(ctx, "Aggref");
+  if (node->aggcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->aggcollid);
+    _fingerprintString(ctx, "aggcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->aggdirectargs != NULL && node->aggdirectargs->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->aggdirectargs, "aggdirectargs");
+    _fingerprintCopyTokens(&subCtx, ctx, "aggdirectargs");
+  }
+  if (node->aggdistinct != NULL && node->aggdistinct->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->aggdistinct, "aggdistinct");
+    _fingerprintCopyTokens(&subCtx, ctx, "aggdistinct");
+  }
+  if (node->aggfilter != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->aggfilter, "aggfilter");
+    _fingerprintCopyTokens(&subCtx, ctx, "aggfilter");
+  }
+  if (node->aggfnoid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->aggfnoid);
+    _fingerprintString(ctx, "aggfnoid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->aggkind != 0) {
+    char str[2] = {node->aggkind, '\0'};
+    _fingerprintString(ctx, "aggkind");
+    _fingerprintString(ctx, str);
+  }
+
+  if (node->agglevelsup != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->agglevelsup);
+    _fingerprintString(ctx, "agglevelsup");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->aggorder != NULL && node->aggorder->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->aggorder, "aggorder");
+    _fingerprintCopyTokens(&subCtx, ctx, "aggorder");
+  }
+
+  if (node->aggstar) {    _fingerprintString(ctx, "aggstar");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->aggtype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->aggtype);
+    _fingerprintString(ctx, "aggtype");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->aggvariadic) {    _fingerprintString(ctx, "aggvariadic");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->inputcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->inputcollid);
+    _fingerprintString(ctx, "inputcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+}
+
+static void
+_fingerprintGroupingFunc(FingerprintContext *ctx, const GroupingFunc *node, const char *field_name)
+{
+  _fingerprintString(ctx, "GroupingFunc");
+  if (node->agglevelsup != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->agglevelsup);
+    _fingerprintString(ctx, "agglevelsup");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->cols != NULL && node->cols->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->cols, "cols");
+    _fingerprintCopyTokens(&subCtx, ctx, "cols");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->refs != NULL && node->refs->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->refs, "refs");
+    _fingerprintCopyTokens(&subCtx, ctx, "refs");
+  }
+}
+
+static void
+_fingerprintWindowFunc(FingerprintContext *ctx, const WindowFunc *node, const char *field_name)
+{
+  _fingerprintString(ctx, "WindowFunc");
+  if (node->aggfilter != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->aggfilter, "aggfilter");
+    _fingerprintCopyTokens(&subCtx, ctx, "aggfilter");
+  }
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->inputcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->inputcollid);
+    _fingerprintString(ctx, "inputcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+
+  if (node->winagg) {    _fingerprintString(ctx, "winagg");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->wincollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->wincollid);
+    _fingerprintString(ctx, "wincollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->winfnoid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->winfnoid);
+    _fingerprintString(ctx, "winfnoid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->winref != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->winref);
+    _fingerprintString(ctx, "winref");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->winstar) {    _fingerprintString(ctx, "winstar");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->wintype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->wintype);
+    _fingerprintString(ctx, "wintype");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintArrayRef(FingerprintContext *ctx, const ArrayRef *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ArrayRef");
+  if (node->refarraytype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->refarraytype);
+    _fingerprintString(ctx, "refarraytype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->refassgnexpr != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->refassgnexpr, "refassgnexpr");
+    _fingerprintCopyTokens(&subCtx, ctx, "refassgnexpr");
+  }
+  if (node->refcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->refcollid);
+    _fingerprintString(ctx, "refcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->refelemtype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->refelemtype);
+    _fingerprintString(ctx, "refelemtype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->refexpr != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->refexpr, "refexpr");
+    _fingerprintCopyTokens(&subCtx, ctx, "refexpr");
+  }
+  if (node->reflowerindexpr != NULL && node->reflowerindexpr->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->reflowerindexpr, "reflowerindexpr");
+    _fingerprintCopyTokens(&subCtx, ctx, "reflowerindexpr");
+  }
+  if (node->reftypmod != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->reftypmod);
+    _fingerprintString(ctx, "reftypmod");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->refupperindexpr != NULL && node->refupperindexpr->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->refupperindexpr, "refupperindexpr");
+    _fingerprintCopyTokens(&subCtx, ctx, "refupperindexpr");
+  }
+}
+
+static void
+_fingerprintFuncExpr(FingerprintContext *ctx, const FuncExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "FuncExpr");
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->funccollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->funccollid);
+    _fingerprintString(ctx, "funccollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->funcformat != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->funcformat);
+    _fingerprintString(ctx, "funcformat");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->funcid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->funcid);
+    _fingerprintString(ctx, "funcid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->funcresulttype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->funcresulttype);
+    _fingerprintString(ctx, "funcresulttype");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->funcretset) {    _fingerprintString(ctx, "funcretset");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->funcvariadic) {    _fingerprintString(ctx, "funcvariadic");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->inputcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->inputcollid);
+    _fingerprintString(ctx, "inputcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+}
+
+static void
+_fingerprintNamedArgExpr(FingerprintContext *ctx, const NamedArgExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "NamedArgExpr");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+  if (node->argnumber != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->argnumber);
+    _fingerprintString(ctx, "argnumber");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+
+  if (node->name != NULL) {
+    _fingerprintString(ctx, "name");
+    _fingerprintString(ctx, node->name);
+  }
+
+}
+
+static void
+_fingerprintOpExpr(FingerprintContext *ctx, const OpExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "OpExpr");
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->inputcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->inputcollid);
+    _fingerprintString(ctx, "inputcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->opcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->opcollid);
+    _fingerprintString(ctx, "opcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->opfuncid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->opfuncid);
+    _fingerprintString(ctx, "opfuncid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->opno != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->opno);
+    _fingerprintString(ctx, "opno");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->opresulttype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->opresulttype);
+    _fingerprintString(ctx, "opresulttype");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->opretset) {    _fingerprintString(ctx, "opretset");
+    _fingerprintString(ctx, "true");
+  }
+
+}
+
+static void
+_fingerprintScalarArrayOpExpr(FingerprintContext *ctx, const ScalarArrayOpExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ScalarArrayOpExpr");
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->inputcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->inputcollid);
+    _fingerprintString(ctx, "inputcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->opfuncid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->opfuncid);
+    _fingerprintString(ctx, "opfuncid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->opno != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->opno);
+    _fingerprintString(ctx, "opno");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->useOr) {    _fingerprintString(ctx, "useOr");
+    _fingerprintString(ctx, "true");
+  }
+
+}
+
+static void
+_fingerprintBoolExpr(FingerprintContext *ctx, const BoolExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "BoolExpr");
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->boolop != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->boolop);
+    _fingerprintString(ctx, "boolop");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+}
+
+static void
+_fingerprintSubLink(FingerprintContext *ctx, const SubLink *node, const char *field_name)
+{
+  _fingerprintString(ctx, "SubLink");
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->operName != NULL && node->operName->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->operName, "operName");
+    _fingerprintCopyTokens(&subCtx, ctx, "operName");
+  }
+  if (node->subLinkId != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->subLinkId);
+    _fingerprintString(ctx, "subLinkId");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->subLinkType != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->subLinkType);
+    _fingerprintString(ctx, "subLinkType");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->subselect != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->subselect, "subselect");
+    _fingerprintCopyTokens(&subCtx, ctx, "subselect");
+  }
+  if (node->testexpr != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->testexpr, "testexpr");
+    _fingerprintCopyTokens(&subCtx, ctx, "testexpr");
+  }
+}
+
+static void
+_fingerprintSubPlan(FingerprintContext *ctx, const SubPlan *node, const char *field_name)
+{
+  _fingerprintString(ctx, "SubPlan");
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->firstColCollation != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->firstColCollation);
+    _fingerprintString(ctx, "firstColCollation");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->firstColType != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->firstColType);
+    _fingerprintString(ctx, "firstColType");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->firstColTypmod != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->firstColTypmod);
+    _fingerprintString(ctx, "firstColTypmod");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->parParam != NULL && node->parParam->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->parParam, "parParam");
+    _fingerprintCopyTokens(&subCtx, ctx, "parParam");
+  }
+  if (node->paramIds != NULL && node->paramIds->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->paramIds, "paramIds");
+    _fingerprintCopyTokens(&subCtx, ctx, "paramIds");
+  }
+if (node->per_call_cost != 0) {
+  char buffer[50];
+  sprintf(buffer, "%f", node->per_call_cost);
+  _fingerprintString(ctx, "per_call_cost");
+  _fingerprintString(ctx, buffer);
+}
+
+  if (node->plan_id != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->plan_id);
+    _fingerprintString(ctx, "plan_id");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->plan_name != NULL) {
+    _fingerprintString(ctx, "plan_name");
+    _fingerprintString(ctx, node->plan_name);
+  }
+
+  if (node->setParam != NULL && node->setParam->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->setParam, "setParam");
+    _fingerprintCopyTokens(&subCtx, ctx, "setParam");
+  }
+if (node->startup_cost != 0) {
+  char buffer[50];
+  sprintf(buffer, "%f", node->startup_cost);
+  _fingerprintString(ctx, "startup_cost");
+  _fingerprintString(ctx, buffer);
+}
+
+  if (node->subLinkType != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->subLinkType);
+    _fingerprintString(ctx, "subLinkType");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->testexpr != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->testexpr, "testexpr");
+    _fingerprintCopyTokens(&subCtx, ctx, "testexpr");
+  }
+
+  if (node->unknownEqFalse) {    _fingerprintString(ctx, "unknownEqFalse");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->useHashTable) {    _fingerprintString(ctx, "useHashTable");
+    _fingerprintString(ctx, "true");
+  }
+
+}
+
+static void
+_fingerprintAlternativeSubPlan(FingerprintContext *ctx, const AlternativeSubPlan *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlternativeSubPlan");
+  if (node->subplans != NULL && node->subplans->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->subplans, "subplans");
+    _fingerprintCopyTokens(&subCtx, ctx, "subplans");
+  }
+}
+
+static void
+_fingerprintFieldSelect(FingerprintContext *ctx, const FieldSelect *node, const char *field_name)
+{
+  _fingerprintString(ctx, "FieldSelect");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+  if (node->fieldnum != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->fieldnum);
+    _fingerprintString(ctx, "fieldnum");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->resultcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resultcollid);
+    _fingerprintString(ctx, "resultcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->resulttype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resulttype);
+    _fingerprintString(ctx, "resulttype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->resulttypmod != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resulttypmod);
+    _fingerprintString(ctx, "resulttypmod");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintFieldStore(FingerprintContext *ctx, const FieldStore *node, const char *field_name)
+{
+  _fingerprintString(ctx, "FieldStore");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+  if (node->fieldnums != NULL && node->fieldnums->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->fieldnums, "fieldnums");
+    _fingerprintCopyTokens(&subCtx, ctx, "fieldnums");
+  }
+  if (node->newvals != NULL && node->newvals->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->newvals, "newvals");
+    _fingerprintCopyTokens(&subCtx, ctx, "newvals");
+  }
+  if (node->resulttype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resulttype);
+    _fingerprintString(ctx, "resulttype");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintRelabelType(FingerprintContext *ctx, const RelabelType *node, const char *field_name)
+{
+  _fingerprintString(ctx, "RelabelType");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->relabelformat != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->relabelformat);
+    _fingerprintString(ctx, "relabelformat");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->resultcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resultcollid);
+    _fingerprintString(ctx, "resultcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->resulttype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resulttype);
+    _fingerprintString(ctx, "resulttype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->resulttypmod != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resulttypmod);
+    _fingerprintString(ctx, "resulttypmod");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintCoerceViaIO(FingerprintContext *ctx, const CoerceViaIO *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CoerceViaIO");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+  if (node->coerceformat != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->coerceformat);
+    _fingerprintString(ctx, "coerceformat");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->resultcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resultcollid);
+    _fingerprintString(ctx, "resultcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->resulttype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resulttype);
+    _fingerprintString(ctx, "resulttype");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintArrayCoerceExpr(FingerprintContext *ctx, const ArrayCoerceExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ArrayCoerceExpr");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+  if (node->coerceformat != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->coerceformat);
+    _fingerprintString(ctx, "coerceformat");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->elemfuncid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->elemfuncid);
+    _fingerprintString(ctx, "elemfuncid");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->isExplicit) {    _fingerprintString(ctx, "isExplicit");
+    _fingerprintString(ctx, "true");
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->resultcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resultcollid);
+    _fingerprintString(ctx, "resultcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->resulttype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resulttype);
+    _fingerprintString(ctx, "resulttype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->resulttypmod != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resulttypmod);
+    _fingerprintString(ctx, "resulttypmod");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintConvertRowtypeExpr(FingerprintContext *ctx, const ConvertRowtypeExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ConvertRowtypeExpr");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+  if (node->convertformat != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->convertformat);
+    _fingerprintString(ctx, "convertformat");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->resulttype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resulttype);
+    _fingerprintString(ctx, "resulttype");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintCollateExpr(FingerprintContext *ctx, const CollateExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CollateExpr");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+  if (node->collOid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->collOid);
+    _fingerprintString(ctx, "collOid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+}
+
+static void
+_fingerprintCaseExpr(FingerprintContext *ctx, const CaseExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CaseExpr");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->casecollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->casecollid);
+    _fingerprintString(ctx, "casecollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->casetype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->casetype);
+    _fingerprintString(ctx, "casetype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->defresult != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->defresult, "defresult");
+    _fingerprintCopyTokens(&subCtx, ctx, "defresult");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+}
+
+static void
+_fingerprintCaseWhen(FingerprintContext *ctx, const CaseWhen *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CaseWhen");
+  if (node->expr != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->expr, "expr");
+    _fingerprintCopyTokens(&subCtx, ctx, "expr");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->result != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->result, "result");
+    _fingerprintCopyTokens(&subCtx, ctx, "result");
+  }
+}
+
+static void
+_fingerprintCaseTestExpr(FingerprintContext *ctx, const CaseTestExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CaseTestExpr");
+  if (node->collation != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->collation);
+    _fingerprintString(ctx, "collation");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->typeId != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->typeId);
+    _fingerprintString(ctx, "typeId");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->typeMod != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->typeMod);
+    _fingerprintString(ctx, "typeMod");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintArrayExpr(FingerprintContext *ctx, const ArrayExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ArrayExpr");
+  if (node->array_collid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->array_collid);
+    _fingerprintString(ctx, "array_collid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->array_typeid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->array_typeid);
+    _fingerprintString(ctx, "array_typeid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->element_typeid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->element_typeid);
+    _fingerprintString(ctx, "element_typeid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->elements != NULL && node->elements->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->elements, "elements");
+    _fingerprintCopyTokens(&subCtx, ctx, "elements");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+
+  if (node->multidims) {    _fingerprintString(ctx, "multidims");
+    _fingerprintString(ctx, "true");
+  }
+
+}
+
+static void
+_fingerprintRowExpr(FingerprintContext *ctx, const RowExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "RowExpr");
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->colnames != NULL && node->colnames->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->colnames, "colnames");
+    _fingerprintCopyTokens(&subCtx, ctx, "colnames");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->row_format != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->row_format);
+    _fingerprintString(ctx, "row_format");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->row_typeid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->row_typeid);
+    _fingerprintString(ctx, "row_typeid");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintRowCompareExpr(FingerprintContext *ctx, const RowCompareExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "RowCompareExpr");
+  if (node->inputcollids != NULL && node->inputcollids->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->inputcollids, "inputcollids");
+    _fingerprintCopyTokens(&subCtx, ctx, "inputcollids");
+  }
+  if (node->largs != NULL && node->largs->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->largs, "largs");
+    _fingerprintCopyTokens(&subCtx, ctx, "largs");
+  }
+  if (node->opfamilies != NULL && node->opfamilies->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->opfamilies, "opfamilies");
+    _fingerprintCopyTokens(&subCtx, ctx, "opfamilies");
+  }
+  if (node->opnos != NULL && node->opnos->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->opnos, "opnos");
+    _fingerprintCopyTokens(&subCtx, ctx, "opnos");
+  }
+  if (node->rargs != NULL && node->rargs->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->rargs, "rargs");
+    _fingerprintCopyTokens(&subCtx, ctx, "rargs");
+  }
+  if (node->rctype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->rctype);
+    _fingerprintString(ctx, "rctype");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintCoalesceExpr(FingerprintContext *ctx, const CoalesceExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CoalesceExpr");
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->coalescecollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->coalescecollid);
+    _fingerprintString(ctx, "coalescecollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->coalescetype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->coalescetype);
+    _fingerprintString(ctx, "coalescetype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+}
+
+static void
+_fingerprintMinMaxExpr(FingerprintContext *ctx, const MinMaxExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "MinMaxExpr");
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->inputcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->inputcollid);
+    _fingerprintString(ctx, "inputcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->minmaxcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->minmaxcollid);
+    _fingerprintString(ctx, "minmaxcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->minmaxtype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->minmaxtype);
+    _fingerprintString(ctx, "minmaxtype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->op != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->op);
+    _fingerprintString(ctx, "op");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintXmlExpr(FingerprintContext *ctx, const XmlExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "XmlExpr");
+  if (node->arg_names != NULL && node->arg_names->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg_names, "arg_names");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg_names");
+  }
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+
+  if (node->name != NULL) {
+    _fingerprintString(ctx, "name");
+    _fingerprintString(ctx, node->name);
+  }
+
+  if (node->named_args != NULL && node->named_args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->named_args, "named_args");
+    _fingerprintCopyTokens(&subCtx, ctx, "named_args");
+  }
+  if (node->op != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->op);
+    _fingerprintString(ctx, "op");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->type != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->type);
+    _fingerprintString(ctx, "type");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->typmod != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->typmod);
+    _fingerprintString(ctx, "typmod");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->xmloption != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->xmloption);
+    _fingerprintString(ctx, "xmloption");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintNullTest(FingerprintContext *ctx, const NullTest *node, const char *field_name)
+{
+  _fingerprintString(ctx, "NullTest");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+
+  if (node->argisrow) {    _fingerprintString(ctx, "argisrow");
+    _fingerprintString(ctx, "true");
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->nulltesttype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->nulltesttype);
+    _fingerprintString(ctx, "nulltesttype");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintBooleanTest(FingerprintContext *ctx, const BooleanTest *node, const char *field_name)
+{
+  _fingerprintString(ctx, "BooleanTest");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+  if (node->booltesttype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->booltesttype);
+    _fingerprintString(ctx, "booltesttype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+}
+
+static void
+_fingerprintCoerceToDomain(FingerprintContext *ctx, const CoerceToDomain *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CoerceToDomain");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+  if (node->coercionformat != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->coercionformat);
+    _fingerprintString(ctx, "coercionformat");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->resultcollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resultcollid);
+    _fingerprintString(ctx, "resultcollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->resulttype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resulttype);
+    _fingerprintString(ctx, "resulttype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->resulttypmod != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resulttypmod);
+    _fingerprintString(ctx, "resulttypmod");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintCoerceToDomainValue(FingerprintContext *ctx, const CoerceToDomainValue *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CoerceToDomainValue");
+  if (node->collation != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->collation);
+    _fingerprintString(ctx, "collation");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->typeId != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->typeId);
+    _fingerprintString(ctx, "typeId");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->typeMod != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->typeMod);
+    _fingerprintString(ctx, "typeMod");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintSetToDefault(FingerprintContext *ctx, const SetToDefault *node, const char *field_name)
+{
+  // Intentionally ignoring all fields for fingerprinting
+}
+
+static void
+_fingerprintCurrentOfExpr(FingerprintContext *ctx, const CurrentOfExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CurrentOfExpr");
+
+  if (node->cursor_name != NULL) {
+    _fingerprintString(ctx, "cursor_name");
+    _fingerprintString(ctx, node->cursor_name);
+  }
+
+  if (node->cursor_param != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->cursor_param);
+    _fingerprintString(ctx, "cursor_param");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->cvarno != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->cvarno);
+    _fingerprintString(ctx, "cvarno");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintInferenceElem(FingerprintContext *ctx, const InferenceElem *node, const char *field_name)
+{
+  _fingerprintString(ctx, "InferenceElem");
+  if (node->expr != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->expr, "expr");
+    _fingerprintCopyTokens(&subCtx, ctx, "expr");
+  }
+  if (node->infercollid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->infercollid);
+    _fingerprintString(ctx, "infercollid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->inferopclass != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->inferopclass);
+    _fingerprintString(ctx, "inferopclass");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintTargetEntry(FingerprintContext *ctx, const TargetEntry *node, const char *field_name)
+{
+  _fingerprintString(ctx, "TargetEntry");
+  if (node->expr != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->expr, "expr");
+    _fingerprintCopyTokens(&subCtx, ctx, "expr");
+  }
+
+  if (node->resjunk) {    _fingerprintString(ctx, "resjunk");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->resname != NULL) {
+    _fingerprintString(ctx, "resname");
+    _fingerprintString(ctx, node->resname);
+  }
+
+  if (node->resno != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resno);
+    _fingerprintString(ctx, "resno");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->resorigcol != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resorigcol);
+    _fingerprintString(ctx, "resorigcol");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->resorigtbl != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resorigtbl);
+    _fingerprintString(ctx, "resorigtbl");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->ressortgroupref != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->ressortgroupref);
+    _fingerprintString(ctx, "ressortgroupref");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintRangeTblRef(FingerprintContext *ctx, const RangeTblRef *node, const char *field_name)
+{
+  _fingerprintString(ctx, "RangeTblRef");
+  if (node->rtindex != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->rtindex);
+    _fingerprintString(ctx, "rtindex");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintJoinExpr(FingerprintContext *ctx, const JoinExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "JoinExpr");
+  if (node->alias != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->alias, "alias");
+    _fingerprintCopyTokens(&subCtx, ctx, "alias");
+  }
+
+  if (node->isNatural) {    _fingerprintString(ctx, "isNatural");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->jointype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->jointype);
+    _fingerprintString(ctx, "jointype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->larg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->larg, "larg");
+    _fingerprintCopyTokens(&subCtx, ctx, "larg");
+  }
+  if (node->quals != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->quals, "quals");
+    _fingerprintCopyTokens(&subCtx, ctx, "quals");
+  }
+  if (node->rarg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->rarg, "rarg");
+    _fingerprintCopyTokens(&subCtx, ctx, "rarg");
+  }
+  if (node->rtindex != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->rtindex);
+    _fingerprintString(ctx, "rtindex");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->usingClause != NULL && node->usingClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->usingClause, "usingClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "usingClause");
+  }
+}
+
+static void
+_fingerprintFromExpr(FingerprintContext *ctx, const FromExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "FromExpr");
+  if (node->fromlist != NULL && node->fromlist->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->fromlist, "fromlist");
+    _fingerprintCopyTokens(&subCtx, ctx, "fromlist");
+  }
+  if (node->quals != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->quals, "quals");
+    _fingerprintCopyTokens(&subCtx, ctx, "quals");
+  }
+}
+
+static void
+_fingerprintOnConflictExpr(FingerprintContext *ctx, const OnConflictExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "OnConflictExpr");
+  if (node->action != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->action);
+    _fingerprintString(ctx, "action");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->arbiterElems != NULL && node->arbiterElems->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arbiterElems, "arbiterElems");
+    _fingerprintCopyTokens(&subCtx, ctx, "arbiterElems");
+  }
+  if (node->arbiterWhere != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arbiterWhere, "arbiterWhere");
+    _fingerprintCopyTokens(&subCtx, ctx, "arbiterWhere");
+  }
+  if (node->constraint != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->constraint);
+    _fingerprintString(ctx, "constraint");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->exclRelIndex != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->exclRelIndex);
+    _fingerprintString(ctx, "exclRelIndex");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->exclRelTlist != NULL && node->exclRelTlist->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->exclRelTlist, "exclRelTlist");
+    _fingerprintCopyTokens(&subCtx, ctx, "exclRelTlist");
+  }
+  if (node->onConflictSet != NULL && node->onConflictSet->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->onConflictSet, "onConflictSet");
+    _fingerprintCopyTokens(&subCtx, ctx, "onConflictSet");
+  }
+  if (node->onConflictWhere != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->onConflictWhere, "onConflictWhere");
+    _fingerprintCopyTokens(&subCtx, ctx, "onConflictWhere");
+  }
+}
+
+static void
+_fingerprintIntoClause(FingerprintContext *ctx, const IntoClause *node, const char *field_name)
+{
+  _fingerprintString(ctx, "IntoClause");
+  if (node->colNames != NULL && node->colNames->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->colNames, "colNames");
+    _fingerprintCopyTokens(&subCtx, ctx, "colNames");
+  }
+  if (node->onCommit != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->onCommit);
+    _fingerprintString(ctx, "onCommit");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+  if (node->rel != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->rel, "rel");
+    _fingerprintCopyTokens(&subCtx, ctx, "rel");
+  }
+
+  if (node->skipData) {    _fingerprintString(ctx, "skipData");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->tableSpaceName != NULL) {
+    _fingerprintString(ctx, "tableSpaceName");
+    _fingerprintString(ctx, node->tableSpaceName);
+  }
+
+  if (node->viewQuery != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->viewQuery, "viewQuery");
+    _fingerprintCopyTokens(&subCtx, ctx, "viewQuery");
+  }
+}
+
+static void
+_fingerprintQuery(FingerprintContext *ctx, const Query *node, const char *field_name)
+{
+  _fingerprintString(ctx, "Query");
+
+  if (node->canSetTag) {    _fingerprintString(ctx, "canSetTag");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->commandType != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->commandType);
+    _fingerprintString(ctx, "commandType");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->constraintDeps != NULL && node->constraintDeps->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->constraintDeps, "constraintDeps");
+    _fingerprintCopyTokens(&subCtx, ctx, "constraintDeps");
+  }
+  if (node->cteList != NULL && node->cteList->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->cteList, "cteList");
+    _fingerprintCopyTokens(&subCtx, ctx, "cteList");
+  }
+  if (node->distinctClause != NULL && node->distinctClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->distinctClause, "distinctClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "distinctClause");
+  }
+  if (node->groupClause != NULL && node->groupClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->groupClause, "groupClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "groupClause");
+  }
+  if (node->groupingSets != NULL && node->groupingSets->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->groupingSets, "groupingSets");
+    _fingerprintCopyTokens(&subCtx, ctx, "groupingSets");
+  }
+
+  if (node->hasAggs) {    _fingerprintString(ctx, "hasAggs");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->hasDistinctOn) {    _fingerprintString(ctx, "hasDistinctOn");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->hasForUpdate) {    _fingerprintString(ctx, "hasForUpdate");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->hasModifyingCTE) {    _fingerprintString(ctx, "hasModifyingCTE");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->hasRecursive) {    _fingerprintString(ctx, "hasRecursive");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->hasRowSecurity) {    _fingerprintString(ctx, "hasRowSecurity");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->hasSubLinks) {    _fingerprintString(ctx, "hasSubLinks");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->hasWindowFuncs) {    _fingerprintString(ctx, "hasWindowFuncs");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->havingQual != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->havingQual, "havingQual");
+    _fingerprintCopyTokens(&subCtx, ctx, "havingQual");
+  }
+  if (node->jointree != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->jointree, "jointree");
+    _fingerprintCopyTokens(&subCtx, ctx, "jointree");
+  }
+  if (node->limitCount != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->limitCount, "limitCount");
+    _fingerprintCopyTokens(&subCtx, ctx, "limitCount");
+  }
+  if (node->limitOffset != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->limitOffset, "limitOffset");
+    _fingerprintCopyTokens(&subCtx, ctx, "limitOffset");
+  }
+  if (node->onConflict != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->onConflict, "onConflict");
+    _fingerprintCopyTokens(&subCtx, ctx, "onConflict");
+  }
+  if (node->queryId != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->queryId);
+    _fingerprintString(ctx, "queryId");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->querySource != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->querySource);
+    _fingerprintString(ctx, "querySource");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->resultRelation != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->resultRelation);
+    _fingerprintString(ctx, "resultRelation");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->returningList != NULL && node->returningList->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->returningList, "returningList");
+    _fingerprintCopyTokens(&subCtx, ctx, "returningList");
+  }
+  if (node->rowMarks != NULL && node->rowMarks->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->rowMarks, "rowMarks");
+    _fingerprintCopyTokens(&subCtx, ctx, "rowMarks");
+  }
+  if (node->rtable != NULL && node->rtable->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->rtable, "rtable");
+    _fingerprintCopyTokens(&subCtx, ctx, "rtable");
+  }
+  if (node->setOperations != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->setOperations, "setOperations");
+    _fingerprintCopyTokens(&subCtx, ctx, "setOperations");
+  }
+  if (node->sortClause != NULL && node->sortClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->sortClause, "sortClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "sortClause");
+  }
+  if (node->targetList != NULL && node->targetList->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->targetList, "targetList");
+    _fingerprintCopyTokens(&subCtx, ctx, "targetList");
+  }
+  if (node->utilityStmt != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->utilityStmt, "utilityStmt");
+    _fingerprintCopyTokens(&subCtx, ctx, "utilityStmt");
+  }
+  if (node->windowClause != NULL && node->windowClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->windowClause, "windowClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "windowClause");
+  }
+  if (node->withCheckOptions != NULL && node->withCheckOptions->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->withCheckOptions, "withCheckOptions");
+    _fingerprintCopyTokens(&subCtx, ctx, "withCheckOptions");
+  }
+}
+
+static void
+_fingerprintInsertStmt(FingerprintContext *ctx, const InsertStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "InsertStmt");
+  if (node->cols != NULL && node->cols->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->cols, "cols");
+    _fingerprintCopyTokens(&subCtx, ctx, "cols");
+  }
+  if (node->onConflictClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->onConflictClause, "onConflictClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "onConflictClause");
+  }
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+  if (node->returningList != NULL && node->returningList->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->returningList, "returningList");
+    _fingerprintCopyTokens(&subCtx, ctx, "returningList");
+  }
+  if (node->selectStmt != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->selectStmt, "selectStmt");
+    _fingerprintCopyTokens(&subCtx, ctx, "selectStmt");
+  }
+  if (node->withClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->withClause, "withClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "withClause");
+  }
+}
+
+static void
+_fingerprintDeleteStmt(FingerprintContext *ctx, const DeleteStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "DeleteStmt");
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+  if (node->returningList != NULL && node->returningList->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->returningList, "returningList");
+    _fingerprintCopyTokens(&subCtx, ctx, "returningList");
+  }
+  if (node->usingClause != NULL && node->usingClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->usingClause, "usingClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "usingClause");
+  }
+  if (node->whereClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->whereClause, "whereClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "whereClause");
+  }
+  if (node->withClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->withClause, "withClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "withClause");
+  }
+}
+
+static void
+_fingerprintUpdateStmt(FingerprintContext *ctx, const UpdateStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "UpdateStmt");
+  if (node->fromClause != NULL && node->fromClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->fromClause, "fromClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "fromClause");
+  }
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+  if (node->returningList != NULL && node->returningList->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->returningList, "returningList");
+    _fingerprintCopyTokens(&subCtx, ctx, "returningList");
+  }
+  if (node->targetList != NULL && node->targetList->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->targetList, "targetList");
+    _fingerprintCopyTokens(&subCtx, ctx, "targetList");
+  }
+  if (node->whereClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->whereClause, "whereClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "whereClause");
+  }
+  if (node->withClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->withClause, "withClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "withClause");
+  }
+}
+
+static void
+_fingerprintSelectStmt(FingerprintContext *ctx, const SelectStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "SelectStmt");
+
+  if (node->all) {    _fingerprintString(ctx, "all");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->distinctClause != NULL && node->distinctClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->distinctClause, "distinctClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "distinctClause");
+  }
+  if (node->fromClause != NULL && node->fromClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->fromClause, "fromClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "fromClause");
+  }
+  if (node->groupClause != NULL && node->groupClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->groupClause, "groupClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "groupClause");
+  }
+  if (node->havingClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->havingClause, "havingClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "havingClause");
+  }
+  if (node->intoClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->intoClause, "intoClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "intoClause");
+  }
+  if (node->larg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->larg, "larg");
+    _fingerprintCopyTokens(&subCtx, ctx, "larg");
+  }
+  if (node->limitCount != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->limitCount, "limitCount");
+    _fingerprintCopyTokens(&subCtx, ctx, "limitCount");
+  }
+  if (node->limitOffset != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->limitOffset, "limitOffset");
+    _fingerprintCopyTokens(&subCtx, ctx, "limitOffset");
+  }
+  if (node->lockingClause != NULL && node->lockingClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->lockingClause, "lockingClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "lockingClause");
+  }
+  if (node->op != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->op);
+    _fingerprintString(ctx, "op");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->rarg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->rarg, "rarg");
+    _fingerprintCopyTokens(&subCtx, ctx, "rarg");
+  }
+  if (node->sortClause != NULL && node->sortClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->sortClause, "sortClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "sortClause");
+  }
+  if (node->targetList != NULL && node->targetList->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->targetList, "targetList");
+    _fingerprintCopyTokens(&subCtx, ctx, "targetList");
+  }
+  if (node->valuesLists != NULL && node->valuesLists->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->valuesLists, "valuesLists");
+    _fingerprintCopyTokens(&subCtx, ctx, "valuesLists");
+  }
+  if (node->whereClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->whereClause, "whereClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "whereClause");
+  }
+  if (node->windowClause != NULL && node->windowClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->windowClause, "windowClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "windowClause");
+  }
+  if (node->withClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->withClause, "withClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "withClause");
+  }
+}
+
+static void
+_fingerprintAlterTableStmt(FingerprintContext *ctx, const AlterTableStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterTableStmt");
+  if (node->cmds != NULL && node->cmds->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->cmds, "cmds");
+    _fingerprintCopyTokens(&subCtx, ctx, "cmds");
+  }
+
+  if (node->missing_ok) {    _fingerprintString(ctx, "missing_ok");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+  if (node->relkind != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->relkind);
+    _fingerprintString(ctx, "relkind");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintAlterTableCmd(FingerprintContext *ctx, const AlterTableCmd *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterTableCmd");
+  if (node->behavior != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->behavior);
+    _fingerprintString(ctx, "behavior");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->def != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->def, "def");
+    _fingerprintCopyTokens(&subCtx, ctx, "def");
+  }
+
+  if (node->missing_ok) {    _fingerprintString(ctx, "missing_ok");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->name != NULL) {
+    _fingerprintString(ctx, "name");
+    _fingerprintString(ctx, node->name);
+  }
+
+  if (node->newowner != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->newowner, "newowner");
+    _fingerprintCopyTokens(&subCtx, ctx, "newowner");
+  }
+  if (node->subtype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->subtype);
+    _fingerprintString(ctx, "subtype");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintAlterDomainStmt(FingerprintContext *ctx, const AlterDomainStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterDomainStmt");
+  if (node->behavior != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->behavior);
+    _fingerprintString(ctx, "behavior");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->def != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->def, "def");
+    _fingerprintCopyTokens(&subCtx, ctx, "def");
+  }
+
+  if (node->missing_ok) {    _fingerprintString(ctx, "missing_ok");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->name != NULL) {
+    _fingerprintString(ctx, "name");
+    _fingerprintString(ctx, node->name);
+  }
+
+  if (node->subtype != 0) {
+    char str[2] = {node->subtype, '\0'};
+    _fingerprintString(ctx, "subtype");
+    _fingerprintString(ctx, str);
+  }
+
+  if (node->typeName != NULL && node->typeName->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->typeName, "typeName");
+    _fingerprintCopyTokens(&subCtx, ctx, "typeName");
+  }
+}
+
+static void
+_fingerprintSetOperationStmt(FingerprintContext *ctx, const SetOperationStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "SetOperationStmt");
+
+  if (node->all) {    _fingerprintString(ctx, "all");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->colCollations != NULL && node->colCollations->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->colCollations, "colCollations");
+    _fingerprintCopyTokens(&subCtx, ctx, "colCollations");
+  }
+  if (node->colTypes != NULL && node->colTypes->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->colTypes, "colTypes");
+    _fingerprintCopyTokens(&subCtx, ctx, "colTypes");
+  }
+  if (node->colTypmods != NULL && node->colTypmods->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->colTypmods, "colTypmods");
+    _fingerprintCopyTokens(&subCtx, ctx, "colTypmods");
+  }
+  if (node->groupClauses != NULL && node->groupClauses->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->groupClauses, "groupClauses");
+    _fingerprintCopyTokens(&subCtx, ctx, "groupClauses");
+  }
+  if (node->larg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->larg, "larg");
+    _fingerprintCopyTokens(&subCtx, ctx, "larg");
+  }
+  if (node->op != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->op);
+    _fingerprintString(ctx, "op");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->rarg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->rarg, "rarg");
+    _fingerprintCopyTokens(&subCtx, ctx, "rarg");
+  }
+}
+
+static void
+_fingerprintGrantStmt(FingerprintContext *ctx, const GrantStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "GrantStmt");
+  if (node->behavior != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->behavior);
+    _fingerprintString(ctx, "behavior");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->grant_option) {    _fingerprintString(ctx, "grant_option");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->grantees != NULL && node->grantees->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->grantees, "grantees");
+    _fingerprintCopyTokens(&subCtx, ctx, "grantees");
+  }
+
+  if (node->is_grant) {    _fingerprintString(ctx, "is_grant");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->objects != NULL && node->objects->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->objects, "objects");
+    _fingerprintCopyTokens(&subCtx, ctx, "objects");
+  }
+  if (node->objtype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->objtype);
+    _fingerprintString(ctx, "objtype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->privileges != NULL && node->privileges->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->privileges, "privileges");
+    _fingerprintCopyTokens(&subCtx, ctx, "privileges");
+  }
+  if (node->targtype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->targtype);
+    _fingerprintString(ctx, "targtype");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintGrantRoleStmt(FingerprintContext *ctx, const GrantRoleStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "GrantRoleStmt");
+
+  if (node->admin_opt) {    _fingerprintString(ctx, "admin_opt");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->behavior != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->behavior);
+    _fingerprintString(ctx, "behavior");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->granted_roles != NULL && node->granted_roles->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->granted_roles, "granted_roles");
+    _fingerprintCopyTokens(&subCtx, ctx, "granted_roles");
+  }
+  if (node->grantee_roles != NULL && node->grantee_roles->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->grantee_roles, "grantee_roles");
+    _fingerprintCopyTokens(&subCtx, ctx, "grantee_roles");
+  }
+  if (node->grantor != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->grantor, "grantor");
+    _fingerprintCopyTokens(&subCtx, ctx, "grantor");
+  }
+
+  if (node->is_grant) {    _fingerprintString(ctx, "is_grant");
+    _fingerprintString(ctx, "true");
+  }
+
+}
+
+static void
+_fingerprintAlterDefaultPrivilegesStmt(FingerprintContext *ctx, const AlterDefaultPrivilegesStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterDefaultPrivilegesStmt");
+  if (node->action != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->action, "action");
+    _fingerprintCopyTokens(&subCtx, ctx, "action");
+  }
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+}
+
+static void
+_fingerprintClosePortalStmt(FingerprintContext *ctx, const ClosePortalStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ClosePortalStmt");
+
+  if (node->portalname != NULL) {
+    _fingerprintString(ctx, "portalname");
+    _fingerprintString(ctx, node->portalname);
+  }
+
+}
+
+static void
+_fingerprintClusterStmt(FingerprintContext *ctx, const ClusterStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ClusterStmt");
+
+  if (node->indexname != NULL) {
+    _fingerprintString(ctx, "indexname");
+    _fingerprintString(ctx, node->indexname);
+  }
+
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+
+  if (node->verbose) {    _fingerprintString(ctx, "verbose");
+    _fingerprintString(ctx, "true");
+  }
+
+}
+
+static void
+_fingerprintCopyStmt(FingerprintContext *ctx, const CopyStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CopyStmt");
+  if (node->attlist != NULL && node->attlist->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->attlist, "attlist");
+    _fingerprintCopyTokens(&subCtx, ctx, "attlist");
+  }
+
+  if (node->filename != NULL) {
+    _fingerprintString(ctx, "filename");
+    _fingerprintString(ctx, node->filename);
+  }
+
+
+  if (node->is_from) {    _fingerprintString(ctx, "is_from");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->is_program) {    _fingerprintString(ctx, "is_program");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+  if (node->query != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->query, "query");
+    _fingerprintCopyTokens(&subCtx, ctx, "query");
+  }
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+}
+
+static void
+_fingerprintCreateStmt(FingerprintContext *ctx, const CreateStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateStmt");
+  if (node->constraints != NULL && node->constraints->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->constraints, "constraints");
+    _fingerprintCopyTokens(&subCtx, ctx, "constraints");
+  }
+
+  if (node->if_not_exists) {    _fingerprintString(ctx, "if_not_exists");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->inhRelations != NULL && node->inhRelations->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->inhRelations, "inhRelations");
+    _fingerprintCopyTokens(&subCtx, ctx, "inhRelations");
+  }
+  if (node->ofTypename != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->ofTypename, "ofTypename");
+    _fingerprintCopyTokens(&subCtx, ctx, "ofTypename");
+  }
+  if (node->oncommit != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->oncommit);
+    _fingerprintString(ctx, "oncommit");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+  if (node->tableElts != NULL && node->tableElts->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->tableElts, "tableElts");
+    _fingerprintCopyTokens(&subCtx, ctx, "tableElts");
+  }
+
+  if (node->tablespacename != NULL) {
+    _fingerprintString(ctx, "tablespacename");
+    _fingerprintString(ctx, node->tablespacename);
+  }
+
+}
+
+static void
+_fingerprintDefineStmt(FingerprintContext *ctx, const DefineStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "DefineStmt");
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->definition != NULL && node->definition->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->definition, "definition");
+    _fingerprintCopyTokens(&subCtx, ctx, "definition");
+  }
+  if (node->defnames != NULL && node->defnames->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->defnames, "defnames");
+    _fingerprintCopyTokens(&subCtx, ctx, "defnames");
+  }
+  if (node->kind != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->kind);
+    _fingerprintString(ctx, "kind");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->oldstyle) {    _fingerprintString(ctx, "oldstyle");
+    _fingerprintString(ctx, "true");
+  }
+
+}
+
+static void
+_fingerprintDropStmt(FingerprintContext *ctx, const DropStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "DropStmt");
+  if (node->arguments != NULL && node->arguments->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arguments, "arguments");
+    _fingerprintCopyTokens(&subCtx, ctx, "arguments");
+  }
+  if (node->behavior != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->behavior);
+    _fingerprintString(ctx, "behavior");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->concurrent) {    _fingerprintString(ctx, "concurrent");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->missing_ok) {    _fingerprintString(ctx, "missing_ok");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->objects != NULL && node->objects->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->objects, "objects");
+    _fingerprintCopyTokens(&subCtx, ctx, "objects");
+  }
+  if (node->removeType != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->removeType);
+    _fingerprintString(ctx, "removeType");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintTruncateStmt(FingerprintContext *ctx, const TruncateStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "TruncateStmt");
+  if (node->behavior != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->behavior);
+    _fingerprintString(ctx, "behavior");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->relations != NULL && node->relations->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relations, "relations");
+    _fingerprintCopyTokens(&subCtx, ctx, "relations");
+  }
+
+  if (node->restart_seqs) {    _fingerprintString(ctx, "restart_seqs");
+    _fingerprintString(ctx, "true");
+  }
+
+}
+
+static void
+_fingerprintCommentStmt(FingerprintContext *ctx, const CommentStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CommentStmt");
+
+  if (node->comment != NULL) {
+    _fingerprintString(ctx, "comment");
+    _fingerprintString(ctx, node->comment);
+  }
+
+  if (node->objargs != NULL && node->objargs->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->objargs, "objargs");
+    _fingerprintCopyTokens(&subCtx, ctx, "objargs");
+  }
+  if (node->objname != NULL && node->objname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->objname, "objname");
+    _fingerprintCopyTokens(&subCtx, ctx, "objname");
+  }
+  if (node->objtype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->objtype);
+    _fingerprintString(ctx, "objtype");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintFetchStmt(FingerprintContext *ctx, const FetchStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "FetchStmt");
+  if (node->direction != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->direction);
+    _fingerprintString(ctx, "direction");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->howMany != 0) {
+    char buffer[50];
+    sprintf(buffer, "%ld", node->howMany);
+    _fingerprintString(ctx, "howMany");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->ismove) {    _fingerprintString(ctx, "ismove");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->portalname != NULL) {
+    _fingerprintString(ctx, "portalname");
+    _fingerprintString(ctx, node->portalname);
+  }
+
+}
+
+static void
+_fingerprintIndexStmt(FingerprintContext *ctx, const IndexStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "IndexStmt");
+
+  if (node->accessMethod != NULL) {
+    _fingerprintString(ctx, "accessMethod");
+    _fingerprintString(ctx, node->accessMethod);
+  }
+
+
+  if (node->concurrent) {    _fingerprintString(ctx, "concurrent");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->deferrable) {    _fingerprintString(ctx, "deferrable");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->excludeOpNames != NULL && node->excludeOpNames->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->excludeOpNames, "excludeOpNames");
+    _fingerprintCopyTokens(&subCtx, ctx, "excludeOpNames");
+  }
+
+  if (node->idxcomment != NULL) {
+    _fingerprintString(ctx, "idxcomment");
+    _fingerprintString(ctx, node->idxcomment);
+  }
+
+
+  if (node->idxname != NULL) {
+    _fingerprintString(ctx, "idxname");
+    _fingerprintString(ctx, node->idxname);
+  }
+
+
+  if (node->if_not_exists) {    _fingerprintString(ctx, "if_not_exists");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->indexOid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->indexOid);
+    _fingerprintString(ctx, "indexOid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->indexParams != NULL && node->indexParams->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->indexParams, "indexParams");
+    _fingerprintCopyTokens(&subCtx, ctx, "indexParams");
+  }
+
+  if (node->initdeferred) {    _fingerprintString(ctx, "initdeferred");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->isconstraint) {    _fingerprintString(ctx, "isconstraint");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->oldNode != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->oldNode);
+    _fingerprintString(ctx, "oldNode");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+
+  if (node->primary) {    _fingerprintString(ctx, "primary");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+
+  if (node->tableSpace != NULL) {
+    _fingerprintString(ctx, "tableSpace");
+    _fingerprintString(ctx, node->tableSpace);
+  }
+
+
+  if (node->transformed) {    _fingerprintString(ctx, "transformed");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->unique) {    _fingerprintString(ctx, "unique");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->whereClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->whereClause, "whereClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "whereClause");
+  }
+}
+
+static void
+_fingerprintCreateFunctionStmt(FingerprintContext *ctx, const CreateFunctionStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateFunctionStmt");
+  if (node->funcname != NULL && node->funcname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->funcname, "funcname");
+    _fingerprintCopyTokens(&subCtx, ctx, "funcname");
+  }
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+  if (node->parameters != NULL && node->parameters->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->parameters, "parameters");
+    _fingerprintCopyTokens(&subCtx, ctx, "parameters");
+  }
+
+  if (node->replace) {    _fingerprintString(ctx, "replace");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->returnType != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->returnType, "returnType");
+    _fingerprintCopyTokens(&subCtx, ctx, "returnType");
+  }
+  if (node->withClause != NULL && node->withClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->withClause, "withClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "withClause");
+  }
+}
+
+static void
+_fingerprintAlterFunctionStmt(FingerprintContext *ctx, const AlterFunctionStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterFunctionStmt");
+  if (node->actions != NULL && node->actions->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->actions, "actions");
+    _fingerprintCopyTokens(&subCtx, ctx, "actions");
+  }
+  if (node->func != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->func, "func");
+    _fingerprintCopyTokens(&subCtx, ctx, "func");
+  }
+}
+
+static void
+_fingerprintDoStmt(FingerprintContext *ctx, const DoStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "DoStmt");
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+}
+
+static void
+_fingerprintRenameStmt(FingerprintContext *ctx, const RenameStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "RenameStmt");
+  if (node->behavior != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->behavior);
+    _fingerprintString(ctx, "behavior");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->missing_ok) {    _fingerprintString(ctx, "missing_ok");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->newname != NULL) {
+    _fingerprintString(ctx, "newname");
+    _fingerprintString(ctx, node->newname);
+  }
+
+  if (node->objarg != NULL && node->objarg->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->objarg, "objarg");
+    _fingerprintCopyTokens(&subCtx, ctx, "objarg");
+  }
+  if (node->object != NULL && node->object->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->object, "object");
+    _fingerprintCopyTokens(&subCtx, ctx, "object");
+  }
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+  if (node->relationType != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->relationType);
+    _fingerprintString(ctx, "relationType");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->renameType != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->renameType);
+    _fingerprintString(ctx, "renameType");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->subname != NULL) {
+    _fingerprintString(ctx, "subname");
+    _fingerprintString(ctx, node->subname);
+  }
+
+}
+
+static void
+_fingerprintRuleStmt(FingerprintContext *ctx, const RuleStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "RuleStmt");
+  if (node->actions != NULL && node->actions->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->actions, "actions");
+    _fingerprintCopyTokens(&subCtx, ctx, "actions");
+  }
+  if (node->event != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->event);
+    _fingerprintString(ctx, "event");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->instead) {    _fingerprintString(ctx, "instead");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+
+  if (node->replace) {    _fingerprintString(ctx, "replace");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->rulename != NULL) {
+    _fingerprintString(ctx, "rulename");
+    _fingerprintString(ctx, node->rulename);
+  }
+
+  if (node->whereClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->whereClause, "whereClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "whereClause");
+  }
+}
+
+static void
+_fingerprintNotifyStmt(FingerprintContext *ctx, const NotifyStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "NotifyStmt");
+
+  if (node->conditionname != NULL) {
+    _fingerprintString(ctx, "conditionname");
+    _fingerprintString(ctx, node->conditionname);
+  }
+
+
+  if (node->payload != NULL) {
+    _fingerprintString(ctx, "payload");
+    _fingerprintString(ctx, node->payload);
+  }
+
+}
+
+static void
+_fingerprintListenStmt(FingerprintContext *ctx, const ListenStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ListenStmt");
+
+  if (node->conditionname != NULL) {
+    _fingerprintString(ctx, "conditionname");
+    _fingerprintString(ctx, node->conditionname);
+  }
+
+}
+
+static void
+_fingerprintUnlistenStmt(FingerprintContext *ctx, const UnlistenStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "UnlistenStmt");
+
+  if (node->conditionname != NULL) {
+    _fingerprintString(ctx, "conditionname");
+    _fingerprintString(ctx, node->conditionname);
+  }
+
+}
+
+static void
+_fingerprintTransactionStmt(FingerprintContext *ctx, const TransactionStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "TransactionStmt");
+
+  if (node->gid != NULL) {
+    _fingerprintString(ctx, "gid");
+    _fingerprintString(ctx, node->gid);
+  }
+
+  if (node->kind != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->kind);
+    _fingerprintString(ctx, "kind");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+}
+
+static void
+_fingerprintViewStmt(FingerprintContext *ctx, const ViewStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ViewStmt");
+  if (node->aliases != NULL && node->aliases->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->aliases, "aliases");
+    _fingerprintCopyTokens(&subCtx, ctx, "aliases");
+  }
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+  if (node->query != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->query, "query");
+    _fingerprintCopyTokens(&subCtx, ctx, "query");
+  }
+
+  if (node->replace) {    _fingerprintString(ctx, "replace");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->view != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->view, "view");
+    _fingerprintCopyTokens(&subCtx, ctx, "view");
+  }
+  if (node->withCheckOption != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->withCheckOption);
+    _fingerprintString(ctx, "withCheckOption");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintLoadStmt(FingerprintContext *ctx, const LoadStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "LoadStmt");
+
+  if (node->filename != NULL) {
+    _fingerprintString(ctx, "filename");
+    _fingerprintString(ctx, node->filename);
+  }
+
+}
+
+static void
+_fingerprintCreateDomainStmt(FingerprintContext *ctx, const CreateDomainStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateDomainStmt");
+  if (node->collClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->collClause, "collClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "collClause");
+  }
+  if (node->constraints != NULL && node->constraints->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->constraints, "constraints");
+    _fingerprintCopyTokens(&subCtx, ctx, "constraints");
+  }
+  if (node->domainname != NULL && node->domainname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->domainname, "domainname");
+    _fingerprintCopyTokens(&subCtx, ctx, "domainname");
+  }
+  if (node->typeName != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->typeName, "typeName");
+    _fingerprintCopyTokens(&subCtx, ctx, "typeName");
+  }
+}
+
+static void
+_fingerprintCreatedbStmt(FingerprintContext *ctx, const CreatedbStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreatedbStmt");
+
+  if (node->dbname != NULL) {
+    _fingerprintString(ctx, "dbname");
+    _fingerprintString(ctx, node->dbname);
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+}
+
+static void
+_fingerprintDropdbStmt(FingerprintContext *ctx, const DropdbStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "DropdbStmt");
+
+  if (node->dbname != NULL) {
+    _fingerprintString(ctx, "dbname");
+    _fingerprintString(ctx, node->dbname);
+  }
+
+
+  if (node->missing_ok) {    _fingerprintString(ctx, "missing_ok");
+    _fingerprintString(ctx, "true");
+  }
+
+}
+
+static void
+_fingerprintVacuumStmt(FingerprintContext *ctx, const VacuumStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "VacuumStmt");
+  if (node->options != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->options);
+    _fingerprintString(ctx, "options");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+  if (node->va_cols != NULL && node->va_cols->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->va_cols, "va_cols");
+    _fingerprintCopyTokens(&subCtx, ctx, "va_cols");
+  }
+}
+
+static void
+_fingerprintExplainStmt(FingerprintContext *ctx, const ExplainStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ExplainStmt");
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+  if (node->query != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->query, "query");
+    _fingerprintCopyTokens(&subCtx, ctx, "query");
+  }
+}
+
+static void
+_fingerprintCreateTableAsStmt(FingerprintContext *ctx, const CreateTableAsStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateTableAsStmt");
+
+  if (node->if_not_exists) {    _fingerprintString(ctx, "if_not_exists");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->into != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->into, "into");
+    _fingerprintCopyTokens(&subCtx, ctx, "into");
+  }
+
+  if (node->is_select_into) {    _fingerprintString(ctx, "is_select_into");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->query != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->query, "query");
+    _fingerprintCopyTokens(&subCtx, ctx, "query");
+  }
+  if (node->relkind != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->relkind);
+    _fingerprintString(ctx, "relkind");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintCreateSeqStmt(FingerprintContext *ctx, const CreateSeqStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateSeqStmt");
+
+  if (node->if_not_exists) {    _fingerprintString(ctx, "if_not_exists");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+  if (node->ownerId != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->ownerId);
+    _fingerprintString(ctx, "ownerId");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->sequence != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->sequence, "sequence");
+    _fingerprintCopyTokens(&subCtx, ctx, "sequence");
+  }
+}
+
+static void
+_fingerprintAlterSeqStmt(FingerprintContext *ctx, const AlterSeqStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterSeqStmt");
+
+  if (node->missing_ok) {    _fingerprintString(ctx, "missing_ok");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+  if (node->sequence != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->sequence, "sequence");
+    _fingerprintCopyTokens(&subCtx, ctx, "sequence");
+  }
+}
+
+static void
+_fingerprintVariableSetStmt(FingerprintContext *ctx, const VariableSetStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "VariableSetStmt");
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+
+  if (node->is_local) {    _fingerprintString(ctx, "is_local");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->kind != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->kind);
+    _fingerprintString(ctx, "kind");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->name != NULL) {
+    _fingerprintString(ctx, "name");
+    _fingerprintString(ctx, node->name);
+  }
+
+}
+
+static void
+_fingerprintVariableShowStmt(FingerprintContext *ctx, const VariableShowStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "VariableShowStmt");
+
+  if (node->name != NULL) {
+    _fingerprintString(ctx, "name");
+    _fingerprintString(ctx, node->name);
+  }
+
+}
+
+static void
+_fingerprintDiscardStmt(FingerprintContext *ctx, const DiscardStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "DiscardStmt");
+  if (node->target != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->target);
+    _fingerprintString(ctx, "target");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintCreateTrigStmt(FingerprintContext *ctx, const CreateTrigStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateTrigStmt");
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->columns != NULL && node->columns->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->columns, "columns");
+    _fingerprintCopyTokens(&subCtx, ctx, "columns");
+  }
+  if (node->constrrel != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->constrrel, "constrrel");
+    _fingerprintCopyTokens(&subCtx, ctx, "constrrel");
+  }
+
+  if (node->deferrable) {    _fingerprintString(ctx, "deferrable");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->events != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->events);
+    _fingerprintString(ctx, "events");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->funcname != NULL && node->funcname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->funcname, "funcname");
+    _fingerprintCopyTokens(&subCtx, ctx, "funcname");
+  }
+
+  if (node->initdeferred) {    _fingerprintString(ctx, "initdeferred");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->isconstraint) {    _fingerprintString(ctx, "isconstraint");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+
+  if (node->row) {    _fingerprintString(ctx, "row");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->timing != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->timing);
+    _fingerprintString(ctx, "timing");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->trigname != NULL) {
+    _fingerprintString(ctx, "trigname");
+    _fingerprintString(ctx, node->trigname);
+  }
+
+  if (node->whenClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->whenClause, "whenClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "whenClause");
+  }
+}
+
+static void
+_fingerprintCreatePLangStmt(FingerprintContext *ctx, const CreatePLangStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreatePLangStmt");
+  if (node->plhandler != NULL && node->plhandler->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->plhandler, "plhandler");
+    _fingerprintCopyTokens(&subCtx, ctx, "plhandler");
+  }
+  if (node->plinline != NULL && node->plinline->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->plinline, "plinline");
+    _fingerprintCopyTokens(&subCtx, ctx, "plinline");
+  }
+
+  if (node->plname != NULL) {
+    _fingerprintString(ctx, "plname");
+    _fingerprintString(ctx, node->plname);
+  }
+
+
+  if (node->pltrusted) {    _fingerprintString(ctx, "pltrusted");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->plvalidator != NULL && node->plvalidator->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->plvalidator, "plvalidator");
+    _fingerprintCopyTokens(&subCtx, ctx, "plvalidator");
+  }
+
+  if (node->replace) {    _fingerprintString(ctx, "replace");
+    _fingerprintString(ctx, "true");
+  }
+
+}
+
+static void
+_fingerprintCreateRoleStmt(FingerprintContext *ctx, const CreateRoleStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateRoleStmt");
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+
+  if (node->role != NULL) {
+    _fingerprintString(ctx, "role");
+    _fingerprintString(ctx, node->role);
+  }
+
+  if (node->stmt_type != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->stmt_type);
+    _fingerprintString(ctx, "stmt_type");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintAlterRoleStmt(FingerprintContext *ctx, const AlterRoleStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterRoleStmt");
+  if (node->action != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->action);
+    _fingerprintString(ctx, "action");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+  if (node->role != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->role, "role");
+    _fingerprintCopyTokens(&subCtx, ctx, "role");
+  }
+}
+
+static void
+_fingerprintDropRoleStmt(FingerprintContext *ctx, const DropRoleStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "DropRoleStmt");
+
+  if (node->missing_ok) {    _fingerprintString(ctx, "missing_ok");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->roles != NULL && node->roles->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->roles, "roles");
+    _fingerprintCopyTokens(&subCtx, ctx, "roles");
+  }
+}
+
+static void
+_fingerprintLockStmt(FingerprintContext *ctx, const LockStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "LockStmt");
+  if (node->mode != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->mode);
+    _fingerprintString(ctx, "mode");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->nowait) {    _fingerprintString(ctx, "nowait");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->relations != NULL && node->relations->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relations, "relations");
+    _fingerprintCopyTokens(&subCtx, ctx, "relations");
+  }
+}
+
+static void
+_fingerprintConstraintsSetStmt(FingerprintContext *ctx, const ConstraintsSetStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ConstraintsSetStmt");
+  if (node->constraints != NULL && node->constraints->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->constraints, "constraints");
+    _fingerprintCopyTokens(&subCtx, ctx, "constraints");
+  }
+
+  if (node->deferred) {    _fingerprintString(ctx, "deferred");
+    _fingerprintString(ctx, "true");
+  }
+
+}
+
+static void
+_fingerprintReindexStmt(FingerprintContext *ctx, const ReindexStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ReindexStmt");
+  if (node->kind != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->kind);
+    _fingerprintString(ctx, "kind");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->name != NULL) {
+    _fingerprintString(ctx, "name");
+    _fingerprintString(ctx, node->name);
+  }
+
+  if (node->options != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->options);
+    _fingerprintString(ctx, "options");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+}
+
+static void
+_fingerprintCheckPointStmt(FingerprintContext *ctx, const CheckPointStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CheckPointStmt");
+}
+
+static void
+_fingerprintCreateSchemaStmt(FingerprintContext *ctx, const CreateSchemaStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateSchemaStmt");
+  if (node->authrole != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->authrole, "authrole");
+    _fingerprintCopyTokens(&subCtx, ctx, "authrole");
+  }
+
+  if (node->if_not_exists) {    _fingerprintString(ctx, "if_not_exists");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->schemaElts != NULL && node->schemaElts->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->schemaElts, "schemaElts");
+    _fingerprintCopyTokens(&subCtx, ctx, "schemaElts");
+  }
+
+  if (node->schemaname != NULL) {
+    _fingerprintString(ctx, "schemaname");
+    _fingerprintString(ctx, node->schemaname);
+  }
+
+}
+
+static void
+_fingerprintAlterDatabaseStmt(FingerprintContext *ctx, const AlterDatabaseStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterDatabaseStmt");
+
+  if (node->dbname != NULL) {
+    _fingerprintString(ctx, "dbname");
+    _fingerprintString(ctx, node->dbname);
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+}
+
+static void
+_fingerprintAlterDatabaseSetStmt(FingerprintContext *ctx, const AlterDatabaseSetStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterDatabaseSetStmt");
+
+  if (node->dbname != NULL) {
+    _fingerprintString(ctx, "dbname");
+    _fingerprintString(ctx, node->dbname);
+  }
+
+  if (node->setstmt != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->setstmt, "setstmt");
+    _fingerprintCopyTokens(&subCtx, ctx, "setstmt");
+  }
+}
+
+static void
+_fingerprintAlterRoleSetStmt(FingerprintContext *ctx, const AlterRoleSetStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterRoleSetStmt");
+
+  if (node->database != NULL) {
+    _fingerprintString(ctx, "database");
+    _fingerprintString(ctx, node->database);
+  }
+
+  if (node->role != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->role, "role");
+    _fingerprintCopyTokens(&subCtx, ctx, "role");
+  }
+  if (node->setstmt != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->setstmt, "setstmt");
+    _fingerprintCopyTokens(&subCtx, ctx, "setstmt");
+  }
+}
+
+static void
+_fingerprintCreateConversionStmt(FingerprintContext *ctx, const CreateConversionStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateConversionStmt");
+  if (node->conversion_name != NULL && node->conversion_name->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->conversion_name, "conversion_name");
+    _fingerprintCopyTokens(&subCtx, ctx, "conversion_name");
+  }
+
+  if (node->def) {    _fingerprintString(ctx, "def");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->for_encoding_name != NULL) {
+    _fingerprintString(ctx, "for_encoding_name");
+    _fingerprintString(ctx, node->for_encoding_name);
+  }
+
+  if (node->func_name != NULL && node->func_name->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->func_name, "func_name");
+    _fingerprintCopyTokens(&subCtx, ctx, "func_name");
+  }
+
+  if (node->to_encoding_name != NULL) {
+    _fingerprintString(ctx, "to_encoding_name");
+    _fingerprintString(ctx, node->to_encoding_name);
+  }
+
+}
+
+static void
+_fingerprintCreateCastStmt(FingerprintContext *ctx, const CreateCastStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateCastStmt");
+  if (node->context != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->context);
+    _fingerprintString(ctx, "context");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->func != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->func, "func");
+    _fingerprintCopyTokens(&subCtx, ctx, "func");
+  }
+
+  if (node->inout) {    _fingerprintString(ctx, "inout");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->sourcetype != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->sourcetype, "sourcetype");
+    _fingerprintCopyTokens(&subCtx, ctx, "sourcetype");
+  }
+  if (node->targettype != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->targettype, "targettype");
+    _fingerprintCopyTokens(&subCtx, ctx, "targettype");
+  }
+}
+
+static void
+_fingerprintCreateOpClassStmt(FingerprintContext *ctx, const CreateOpClassStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateOpClassStmt");
+
+  if (node->amname != NULL) {
+    _fingerprintString(ctx, "amname");
+    _fingerprintString(ctx, node->amname);
+  }
+
+  if (node->datatype != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->datatype, "datatype");
+    _fingerprintCopyTokens(&subCtx, ctx, "datatype");
+  }
+
+  if (node->isDefault) {    _fingerprintString(ctx, "isDefault");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->items != NULL && node->items->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->items, "items");
+    _fingerprintCopyTokens(&subCtx, ctx, "items");
+  }
+  if (node->opclassname != NULL && node->opclassname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->opclassname, "opclassname");
+    _fingerprintCopyTokens(&subCtx, ctx, "opclassname");
+  }
+  if (node->opfamilyname != NULL && node->opfamilyname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->opfamilyname, "opfamilyname");
+    _fingerprintCopyTokens(&subCtx, ctx, "opfamilyname");
+  }
+}
+
+static void
+_fingerprintCreateOpFamilyStmt(FingerprintContext *ctx, const CreateOpFamilyStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateOpFamilyStmt");
+
+  if (node->amname != NULL) {
+    _fingerprintString(ctx, "amname");
+    _fingerprintString(ctx, node->amname);
+  }
+
+  if (node->opfamilyname != NULL && node->opfamilyname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->opfamilyname, "opfamilyname");
+    _fingerprintCopyTokens(&subCtx, ctx, "opfamilyname");
+  }
+}
+
+static void
+_fingerprintAlterOpFamilyStmt(FingerprintContext *ctx, const AlterOpFamilyStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterOpFamilyStmt");
+
+  if (node->amname != NULL) {
+    _fingerprintString(ctx, "amname");
+    _fingerprintString(ctx, node->amname);
+  }
+
+
+  if (node->isDrop) {    _fingerprintString(ctx, "isDrop");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->items != NULL && node->items->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->items, "items");
+    _fingerprintCopyTokens(&subCtx, ctx, "items");
+  }
+  if (node->opfamilyname != NULL && node->opfamilyname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->opfamilyname, "opfamilyname");
+    _fingerprintCopyTokens(&subCtx, ctx, "opfamilyname");
+  }
+}
+
+static void
+_fingerprintPrepareStmt(FingerprintContext *ctx, const PrepareStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "PrepareStmt");
+  if (node->argtypes != NULL && node->argtypes->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->argtypes, "argtypes");
+    _fingerprintCopyTokens(&subCtx, ctx, "argtypes");
+  }
+  // Intentionally ignoring node->name for fingerprinting
+  if (node->query != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->query, "query");
+    _fingerprintCopyTokens(&subCtx, ctx, "query");
+  }
+}
+
+static void
+_fingerprintExecuteStmt(FingerprintContext *ctx, const ExecuteStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ExecuteStmt");
+  // Intentionally ignoring node->name for fingerprinting
+  if (node->params != NULL && node->params->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->params, "params");
+    _fingerprintCopyTokens(&subCtx, ctx, "params");
+  }
+}
+
+static void
+_fingerprintDeallocateStmt(FingerprintContext *ctx, const DeallocateStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "DeallocateStmt");
+  // Intentionally ignoring node->name for fingerprinting
+}
+
+static void
+_fingerprintDeclareCursorStmt(FingerprintContext *ctx, const DeclareCursorStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "DeclareCursorStmt");
+  if (node->options != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->options);
+    _fingerprintString(ctx, "options");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->portalname != NULL) {
+    _fingerprintString(ctx, "portalname");
+    _fingerprintString(ctx, node->portalname);
+  }
+
+  if (node->query != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->query, "query");
+    _fingerprintCopyTokens(&subCtx, ctx, "query");
+  }
+}
+
+static void
+_fingerprintCreateTableSpaceStmt(FingerprintContext *ctx, const CreateTableSpaceStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateTableSpaceStmt");
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+  if (node->owner != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->owner, "owner");
+    _fingerprintCopyTokens(&subCtx, ctx, "owner");
+  }
+
+  if (node->tablespacename != NULL) {
+    _fingerprintString(ctx, "tablespacename");
+    _fingerprintString(ctx, node->tablespacename);
+  }
+
+}
+
+static void
+_fingerprintDropTableSpaceStmt(FingerprintContext *ctx, const DropTableSpaceStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "DropTableSpaceStmt");
+
+  if (node->missing_ok) {    _fingerprintString(ctx, "missing_ok");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->tablespacename != NULL) {
+    _fingerprintString(ctx, "tablespacename");
+    _fingerprintString(ctx, node->tablespacename);
+  }
+
+}
+
+static void
+_fingerprintAlterObjectSchemaStmt(FingerprintContext *ctx, const AlterObjectSchemaStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterObjectSchemaStmt");
+
+  if (node->missing_ok) {    _fingerprintString(ctx, "missing_ok");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->newschema != NULL) {
+    _fingerprintString(ctx, "newschema");
+    _fingerprintString(ctx, node->newschema);
+  }
+
+  if (node->objarg != NULL && node->objarg->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->objarg, "objarg");
+    _fingerprintCopyTokens(&subCtx, ctx, "objarg");
+  }
+  if (node->object != NULL && node->object->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->object, "object");
+    _fingerprintCopyTokens(&subCtx, ctx, "object");
+  }
+  if (node->objectType != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->objectType);
+    _fingerprintString(ctx, "objectType");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+}
+
+static void
+_fingerprintAlterOwnerStmt(FingerprintContext *ctx, const AlterOwnerStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterOwnerStmt");
+  if (node->newowner != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->newowner, "newowner");
+    _fingerprintCopyTokens(&subCtx, ctx, "newowner");
+  }
+  if (node->objarg != NULL && node->objarg->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->objarg, "objarg");
+    _fingerprintCopyTokens(&subCtx, ctx, "objarg");
+  }
+  if (node->object != NULL && node->object->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->object, "object");
+    _fingerprintCopyTokens(&subCtx, ctx, "object");
+  }
+  if (node->objectType != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->objectType);
+    _fingerprintString(ctx, "objectType");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+}
+
+static void
+_fingerprintDropOwnedStmt(FingerprintContext *ctx, const DropOwnedStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "DropOwnedStmt");
+  if (node->behavior != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->behavior);
+    _fingerprintString(ctx, "behavior");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->roles != NULL && node->roles->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->roles, "roles");
+    _fingerprintCopyTokens(&subCtx, ctx, "roles");
+  }
+}
+
+static void
+_fingerprintReassignOwnedStmt(FingerprintContext *ctx, const ReassignOwnedStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ReassignOwnedStmt");
+  if (node->newrole != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->newrole, "newrole");
+    _fingerprintCopyTokens(&subCtx, ctx, "newrole");
+  }
+  if (node->roles != NULL && node->roles->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->roles, "roles");
+    _fingerprintCopyTokens(&subCtx, ctx, "roles");
+  }
+}
+
+static void
+_fingerprintCompositeTypeStmt(FingerprintContext *ctx, const CompositeTypeStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CompositeTypeStmt");
+  if (node->coldeflist != NULL && node->coldeflist->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->coldeflist, "coldeflist");
+    _fingerprintCopyTokens(&subCtx, ctx, "coldeflist");
+  }
+  if (node->typevar != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->typevar, "typevar");
+    _fingerprintCopyTokens(&subCtx, ctx, "typevar");
+  }
+}
+
+static void
+_fingerprintCreateEnumStmt(FingerprintContext *ctx, const CreateEnumStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateEnumStmt");
+  if (node->typeName != NULL && node->typeName->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->typeName, "typeName");
+    _fingerprintCopyTokens(&subCtx, ctx, "typeName");
+  }
+  if (node->vals != NULL && node->vals->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->vals, "vals");
+    _fingerprintCopyTokens(&subCtx, ctx, "vals");
+  }
+}
+
+static void
+_fingerprintCreateRangeStmt(FingerprintContext *ctx, const CreateRangeStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateRangeStmt");
+  if (node->params != NULL && node->params->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->params, "params");
+    _fingerprintCopyTokens(&subCtx, ctx, "params");
+  }
+  if (node->typeName != NULL && node->typeName->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->typeName, "typeName");
+    _fingerprintCopyTokens(&subCtx, ctx, "typeName");
+  }
+}
+
+static void
+_fingerprintAlterEnumStmt(FingerprintContext *ctx, const AlterEnumStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterEnumStmt");
+
+  if (node->newVal != NULL) {
+    _fingerprintString(ctx, "newVal");
+    _fingerprintString(ctx, node->newVal);
+  }
+
+
+  if (node->newValIsAfter) {    _fingerprintString(ctx, "newValIsAfter");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->newValNeighbor != NULL) {
+    _fingerprintString(ctx, "newValNeighbor");
+    _fingerprintString(ctx, node->newValNeighbor);
+  }
+
+
+  if (node->skipIfExists) {    _fingerprintString(ctx, "skipIfExists");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->typeName != NULL && node->typeName->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->typeName, "typeName");
+    _fingerprintCopyTokens(&subCtx, ctx, "typeName");
+  }
+}
+
+static void
+_fingerprintAlterTSDictionaryStmt(FingerprintContext *ctx, const AlterTSDictionaryStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterTSDictionaryStmt");
+  if (node->dictname != NULL && node->dictname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->dictname, "dictname");
+    _fingerprintCopyTokens(&subCtx, ctx, "dictname");
+  }
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+}
+
+static void
+_fingerprintAlterTSConfigurationStmt(FingerprintContext *ctx, const AlterTSConfigurationStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterTSConfigurationStmt");
+  if (node->cfgname != NULL && node->cfgname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->cfgname, "cfgname");
+    _fingerprintCopyTokens(&subCtx, ctx, "cfgname");
+  }
+  if (node->dicts != NULL && node->dicts->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->dicts, "dicts");
+    _fingerprintCopyTokens(&subCtx, ctx, "dicts");
+  }
+  if (node->kind != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->kind);
+    _fingerprintString(ctx, "kind");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->missing_ok) {    _fingerprintString(ctx, "missing_ok");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->override) {    _fingerprintString(ctx, "override");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->replace) {    _fingerprintString(ctx, "replace");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->tokentype != NULL && node->tokentype->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->tokentype, "tokentype");
+    _fingerprintCopyTokens(&subCtx, ctx, "tokentype");
+  }
+}
+
+static void
+_fingerprintCreateFdwStmt(FingerprintContext *ctx, const CreateFdwStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateFdwStmt");
+
+  if (node->fdwname != NULL) {
+    _fingerprintString(ctx, "fdwname");
+    _fingerprintString(ctx, node->fdwname);
+  }
+
+  if (node->func_options != NULL && node->func_options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->func_options, "func_options");
+    _fingerprintCopyTokens(&subCtx, ctx, "func_options");
+  }
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+}
+
+static void
+_fingerprintAlterFdwStmt(FingerprintContext *ctx, const AlterFdwStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterFdwStmt");
+
+  if (node->fdwname != NULL) {
+    _fingerprintString(ctx, "fdwname");
+    _fingerprintString(ctx, node->fdwname);
+  }
+
+  if (node->func_options != NULL && node->func_options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->func_options, "func_options");
+    _fingerprintCopyTokens(&subCtx, ctx, "func_options");
+  }
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+}
+
+static void
+_fingerprintCreateForeignServerStmt(FingerprintContext *ctx, const CreateForeignServerStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateForeignServerStmt");
+
+  if (node->fdwname != NULL) {
+    _fingerprintString(ctx, "fdwname");
+    _fingerprintString(ctx, node->fdwname);
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+
+  if (node->servername != NULL) {
+    _fingerprintString(ctx, "servername");
+    _fingerprintString(ctx, node->servername);
+  }
+
+
+  if (node->servertype != NULL) {
+    _fingerprintString(ctx, "servertype");
+    _fingerprintString(ctx, node->servertype);
+  }
+
+
+  if (node->version != NULL) {
+    _fingerprintString(ctx, "version");
+    _fingerprintString(ctx, node->version);
+  }
+
+}
+
+static void
+_fingerprintAlterForeignServerStmt(FingerprintContext *ctx, const AlterForeignServerStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterForeignServerStmt");
+
+  if (node->has_version) {    _fingerprintString(ctx, "has_version");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+
+  if (node->servername != NULL) {
+    _fingerprintString(ctx, "servername");
+    _fingerprintString(ctx, node->servername);
+  }
+
+
+  if (node->version != NULL) {
+    _fingerprintString(ctx, "version");
+    _fingerprintString(ctx, node->version);
+  }
+
+}
+
+static void
+_fingerprintCreateUserMappingStmt(FingerprintContext *ctx, const CreateUserMappingStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateUserMappingStmt");
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+
+  if (node->servername != NULL) {
+    _fingerprintString(ctx, "servername");
+    _fingerprintString(ctx, node->servername);
+  }
+
+  if (node->user != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->user, "user");
+    _fingerprintCopyTokens(&subCtx, ctx, "user");
+  }
+}
+
+static void
+_fingerprintAlterUserMappingStmt(FingerprintContext *ctx, const AlterUserMappingStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterUserMappingStmt");
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+
+  if (node->servername != NULL) {
+    _fingerprintString(ctx, "servername");
+    _fingerprintString(ctx, node->servername);
+  }
+
+  if (node->user != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->user, "user");
+    _fingerprintCopyTokens(&subCtx, ctx, "user");
+  }
+}
+
+static void
+_fingerprintDropUserMappingStmt(FingerprintContext *ctx, const DropUserMappingStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "DropUserMappingStmt");
+
+  if (node->missing_ok) {    _fingerprintString(ctx, "missing_ok");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->servername != NULL) {
+    _fingerprintString(ctx, "servername");
+    _fingerprintString(ctx, node->servername);
+  }
+
+  if (node->user != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->user, "user");
+    _fingerprintCopyTokens(&subCtx, ctx, "user");
+  }
+}
+
+static void
+_fingerprintAlterTableSpaceOptionsStmt(FingerprintContext *ctx, const AlterTableSpaceOptionsStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterTableSpaceOptionsStmt");
+
+  if (node->isReset) {    _fingerprintString(ctx, "isReset");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+
+  if (node->tablespacename != NULL) {
+    _fingerprintString(ctx, "tablespacename");
+    _fingerprintString(ctx, node->tablespacename);
+  }
+
+}
+
+static void
+_fingerprintAlterTableMoveAllStmt(FingerprintContext *ctx, const AlterTableMoveAllStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterTableMoveAllStmt");
+
+  if (node->new_tablespacename != NULL) {
+    _fingerprintString(ctx, "new_tablespacename");
+    _fingerprintString(ctx, node->new_tablespacename);
+  }
+
+
+  if (node->nowait) {    _fingerprintString(ctx, "nowait");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->objtype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->objtype);
+    _fingerprintString(ctx, "objtype");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->orig_tablespacename != NULL) {
+    _fingerprintString(ctx, "orig_tablespacename");
+    _fingerprintString(ctx, node->orig_tablespacename);
+  }
+
+  if (node->roles != NULL && node->roles->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->roles, "roles");
+    _fingerprintCopyTokens(&subCtx, ctx, "roles");
+  }
+}
+
+static void
+_fingerprintSecLabelStmt(FingerprintContext *ctx, const SecLabelStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "SecLabelStmt");
+
+  if (node->label != NULL) {
+    _fingerprintString(ctx, "label");
+    _fingerprintString(ctx, node->label);
+  }
+
+  if (node->objargs != NULL && node->objargs->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->objargs, "objargs");
+    _fingerprintCopyTokens(&subCtx, ctx, "objargs");
+  }
+  if (node->objname != NULL && node->objname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->objname, "objname");
+    _fingerprintCopyTokens(&subCtx, ctx, "objname");
+  }
+  if (node->objtype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->objtype);
+    _fingerprintString(ctx, "objtype");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->provider != NULL) {
+    _fingerprintString(ctx, "provider");
+    _fingerprintString(ctx, node->provider);
+  }
+
+}
+
+static void
+_fingerprintCreateForeignTableStmt(FingerprintContext *ctx, const CreateForeignTableStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateForeignTableStmt");
+  _fingerprintString(ctx, "base");
+  _fingerprintNode(ctx, &node->base, "base");
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+
+  if (node->servername != NULL) {
+    _fingerprintString(ctx, "servername");
+    _fingerprintString(ctx, node->servername);
+  }
+
+}
+
+static void
+_fingerprintImportForeignSchemaStmt(FingerprintContext *ctx, const ImportForeignSchemaStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ImportForeignSchemaStmt");
+  if (node->list_type != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->list_type);
+    _fingerprintString(ctx, "list_type");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->local_schema != NULL) {
+    _fingerprintString(ctx, "local_schema");
+    _fingerprintString(ctx, node->local_schema);
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+
+  if (node->remote_schema != NULL) {
+    _fingerprintString(ctx, "remote_schema");
+    _fingerprintString(ctx, node->remote_schema);
+  }
+
+
+  if (node->server_name != NULL) {
+    _fingerprintString(ctx, "server_name");
+    _fingerprintString(ctx, node->server_name);
+  }
+
+  if (node->table_list != NULL && node->table_list->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->table_list, "table_list");
+    _fingerprintCopyTokens(&subCtx, ctx, "table_list");
+  }
+}
+
+static void
+_fingerprintCreateExtensionStmt(FingerprintContext *ctx, const CreateExtensionStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateExtensionStmt");
+
+  if (node->extname != NULL) {
+    _fingerprintString(ctx, "extname");
+    _fingerprintString(ctx, node->extname);
+  }
+
+
+  if (node->if_not_exists) {    _fingerprintString(ctx, "if_not_exists");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+}
+
+static void
+_fingerprintAlterExtensionStmt(FingerprintContext *ctx, const AlterExtensionStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterExtensionStmt");
+
+  if (node->extname != NULL) {
+    _fingerprintString(ctx, "extname");
+    _fingerprintString(ctx, node->extname);
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+}
+
+static void
+_fingerprintAlterExtensionContentsStmt(FingerprintContext *ctx, const AlterExtensionContentsStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterExtensionContentsStmt");
+  if (node->action != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->action);
+    _fingerprintString(ctx, "action");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->extname != NULL) {
+    _fingerprintString(ctx, "extname");
+    _fingerprintString(ctx, node->extname);
+  }
+
+  if (node->objargs != NULL && node->objargs->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->objargs, "objargs");
+    _fingerprintCopyTokens(&subCtx, ctx, "objargs");
+  }
+  if (node->objname != NULL && node->objname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->objname, "objname");
+    _fingerprintCopyTokens(&subCtx, ctx, "objname");
+  }
+  if (node->objtype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->objtype);
+    _fingerprintString(ctx, "objtype");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintCreateEventTrigStmt(FingerprintContext *ctx, const CreateEventTrigStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateEventTrigStmt");
+
+  if (node->eventname != NULL) {
+    _fingerprintString(ctx, "eventname");
+    _fingerprintString(ctx, node->eventname);
+  }
+
+  if (node->funcname != NULL && node->funcname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->funcname, "funcname");
+    _fingerprintCopyTokens(&subCtx, ctx, "funcname");
+  }
+
+  if (node->trigname != NULL) {
+    _fingerprintString(ctx, "trigname");
+    _fingerprintString(ctx, node->trigname);
+  }
+
+  if (node->whenclause != NULL && node->whenclause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->whenclause, "whenclause");
+    _fingerprintCopyTokens(&subCtx, ctx, "whenclause");
+  }
+}
+
+static void
+_fingerprintAlterEventTrigStmt(FingerprintContext *ctx, const AlterEventTrigStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterEventTrigStmt");
+  if (node->tgenabled != 0) {
+    char str[2] = {node->tgenabled, '\0'};
+    _fingerprintString(ctx, "tgenabled");
+    _fingerprintString(ctx, str);
+  }
+
+
+  if (node->trigname != NULL) {
+    _fingerprintString(ctx, "trigname");
+    _fingerprintString(ctx, node->trigname);
+  }
+
+}
+
+static void
+_fingerprintRefreshMatViewStmt(FingerprintContext *ctx, const RefreshMatViewStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "RefreshMatViewStmt");
+
+  if (node->concurrent) {    _fingerprintString(ctx, "concurrent");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+
+  if (node->skipData) {    _fingerprintString(ctx, "skipData");
+    _fingerprintString(ctx, "true");
+  }
+
+}
+
+static void
+_fingerprintReplicaIdentityStmt(FingerprintContext *ctx, const ReplicaIdentityStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ReplicaIdentityStmt");
+  if (node->identity_type != 0) {
+    char str[2] = {node->identity_type, '\0'};
+    _fingerprintString(ctx, "identity_type");
+    _fingerprintString(ctx, str);
+  }
+
+
+  if (node->name != NULL) {
+    _fingerprintString(ctx, "name");
+    _fingerprintString(ctx, node->name);
+  }
+
+}
+
+static void
+_fingerprintAlterSystemStmt(FingerprintContext *ctx, const AlterSystemStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterSystemStmt");
+  if (node->setstmt != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->setstmt, "setstmt");
+    _fingerprintCopyTokens(&subCtx, ctx, "setstmt");
+  }
+}
+
+static void
+_fingerprintCreatePolicyStmt(FingerprintContext *ctx, const CreatePolicyStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreatePolicyStmt");
+
+  if (node->cmd_name != NULL) {
+    _fingerprintString(ctx, "cmd_name");
+    _fingerprintString(ctx, node->cmd_name);
+  }
+
+
+  if (node->policy_name != NULL) {
+    _fingerprintString(ctx, "policy_name");
+    _fingerprintString(ctx, node->policy_name);
+  }
+
+  if (node->qual != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->qual, "qual");
+    _fingerprintCopyTokens(&subCtx, ctx, "qual");
+  }
+  if (node->roles != NULL && node->roles->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->roles, "roles");
+    _fingerprintCopyTokens(&subCtx, ctx, "roles");
+  }
+  if (node->table != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->table, "table");
+    _fingerprintCopyTokens(&subCtx, ctx, "table");
+  }
+  if (node->with_check != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->with_check, "with_check");
+    _fingerprintCopyTokens(&subCtx, ctx, "with_check");
+  }
+}
+
+static void
+_fingerprintAlterPolicyStmt(FingerprintContext *ctx, const AlterPolicyStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AlterPolicyStmt");
+
+  if (node->policy_name != NULL) {
+    _fingerprintString(ctx, "policy_name");
+    _fingerprintString(ctx, node->policy_name);
+  }
+
+  if (node->qual != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->qual, "qual");
+    _fingerprintCopyTokens(&subCtx, ctx, "qual");
+  }
+  if (node->roles != NULL && node->roles->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->roles, "roles");
+    _fingerprintCopyTokens(&subCtx, ctx, "roles");
+  }
+  if (node->table != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->table, "table");
+    _fingerprintCopyTokens(&subCtx, ctx, "table");
+  }
+  if (node->with_check != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->with_check, "with_check");
+    _fingerprintCopyTokens(&subCtx, ctx, "with_check");
+  }
+}
+
+static void
+_fingerprintCreateTransformStmt(FingerprintContext *ctx, const CreateTransformStmt *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateTransformStmt");
+  if (node->fromsql != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->fromsql, "fromsql");
+    _fingerprintCopyTokens(&subCtx, ctx, "fromsql");
+  }
+
+  if (node->lang != NULL) {
+    _fingerprintString(ctx, "lang");
+    _fingerprintString(ctx, node->lang);
+  }
+
+
+  if (node->replace) {    _fingerprintString(ctx, "replace");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->tosql != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->tosql, "tosql");
+    _fingerprintCopyTokens(&subCtx, ctx, "tosql");
+  }
+  if (node->type_name != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->type_name, "type_name");
+    _fingerprintCopyTokens(&subCtx, ctx, "type_name");
+  }
+}
+
+static void
+_fingerprintA_Expr(FingerprintContext *ctx, const A_Expr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "A_Expr");
+  if (node->kind != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->kind);
+    _fingerprintString(ctx, "kind");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->lexpr != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->lexpr, "lexpr");
+    _fingerprintCopyTokens(&subCtx, ctx, "lexpr");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->name != NULL && node->name->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->name, "name");
+    _fingerprintCopyTokens(&subCtx, ctx, "name");
+  }
+  if (node->rexpr != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->rexpr, "rexpr");
+    _fingerprintCopyTokens(&subCtx, ctx, "rexpr");
+  }
+}
+
+static void
+_fingerprintColumnRef(FingerprintContext *ctx, const ColumnRef *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ColumnRef");
+  if (node->fields != NULL && node->fields->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->fields, "fields");
+    _fingerprintCopyTokens(&subCtx, ctx, "fields");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+}
+
+static void
+_fingerprintParamRef(FingerprintContext *ctx, const ParamRef *node, const char *field_name)
+{
+  // Intentionally ignoring all fields for fingerprinting
+}
+
+static void
+_fingerprintA_Const(FingerprintContext *ctx, const A_Const *node, const char *field_name)
+{
+  // Intentionally ignoring all fields for fingerprinting
+}
+
+static void
+_fingerprintFuncCall(FingerprintContext *ctx, const FuncCall *node, const char *field_name)
+{
+  _fingerprintString(ctx, "FuncCall");
+
+  if (node->agg_distinct) {    _fingerprintString(ctx, "agg_distinct");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->agg_filter != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->agg_filter, "agg_filter");
+    _fingerprintCopyTokens(&subCtx, ctx, "agg_filter");
+  }
+  if (node->agg_order != NULL && node->agg_order->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->agg_order, "agg_order");
+    _fingerprintCopyTokens(&subCtx, ctx, "agg_order");
+  }
+
+  if (node->agg_star) {    _fingerprintString(ctx, "agg_star");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->agg_within_group) {    _fingerprintString(ctx, "agg_within_group");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+
+  if (node->func_variadic) {    _fingerprintString(ctx, "func_variadic");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->funcname != NULL && node->funcname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->funcname, "funcname");
+    _fingerprintCopyTokens(&subCtx, ctx, "funcname");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->over != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->over, "over");
+    _fingerprintCopyTokens(&subCtx, ctx, "over");
+  }
+}
+
+static void
+_fingerprintA_Star(FingerprintContext *ctx, const A_Star *node, const char *field_name)
+{
+  _fingerprintString(ctx, "A_Star");
+}
+
+static void
+_fingerprintA_Indices(FingerprintContext *ctx, const A_Indices *node, const char *field_name)
+{
+  _fingerprintString(ctx, "A_Indices");
+  if (node->lidx != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->lidx, "lidx");
+    _fingerprintCopyTokens(&subCtx, ctx, "lidx");
+  }
+  if (node->uidx != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->uidx, "uidx");
+    _fingerprintCopyTokens(&subCtx, ctx, "uidx");
+  }
+}
+
+static void
+_fingerprintA_Indirection(FingerprintContext *ctx, const A_Indirection *node, const char *field_name)
+{
+  _fingerprintString(ctx, "A_Indirection");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+  if (node->indirection != NULL && node->indirection->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->indirection, "indirection");
+    _fingerprintCopyTokens(&subCtx, ctx, "indirection");
+  }
+}
+
+static void
+_fingerprintA_ArrayExpr(FingerprintContext *ctx, const A_ArrayExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "A_ArrayExpr");
+  if (node->elements != NULL && node->elements->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->elements, "elements");
+    _fingerprintCopyTokens(&subCtx, ctx, "elements");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+}
+
+static void
+_fingerprintResTarget(FingerprintContext *ctx, const ResTarget *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ResTarget");
+  if (node->indirection != NULL && node->indirection->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->indirection, "indirection");
+    _fingerprintCopyTokens(&subCtx, ctx, "indirection");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->name != NULL && (field_name == NULL || strcmp(field_name, "targetList") != 0)) {
+    _fingerprintString(ctx, "name");
+    _fingerprintString(ctx, node->name);
+  }
+  if (node->val != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->val, "val");
+    _fingerprintCopyTokens(&subCtx, ctx, "val");
+  }
+}
+
+static void
+_fingerprintMultiAssignRef(FingerprintContext *ctx, const MultiAssignRef *node, const char *field_name)
+{
+  _fingerprintString(ctx, "MultiAssignRef");
+  if (node->colno != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->colno);
+    _fingerprintString(ctx, "colno");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->ncolumns != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->ncolumns);
+    _fingerprintString(ctx, "ncolumns");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->source != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->source, "source");
+    _fingerprintCopyTokens(&subCtx, ctx, "source");
+  }
+}
+
+static void
+_fingerprintTypeCast(FingerprintContext *ctx, const TypeCast *node, const char *field_name)
+{
+  _fingerprintString(ctx, "TypeCast");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->typeName != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->typeName, "typeName");
+    _fingerprintCopyTokens(&subCtx, ctx, "typeName");
+  }
+}
+
+static void
+_fingerprintCollateClause(FingerprintContext *ctx, const CollateClause *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CollateClause");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+  if (node->collname != NULL && node->collname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->collname, "collname");
+    _fingerprintCopyTokens(&subCtx, ctx, "collname");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+}
+
+static void
+_fingerprintSortBy(FingerprintContext *ctx, const SortBy *node, const char *field_name)
+{
+  _fingerprintString(ctx, "SortBy");
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->node != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->node, "node");
+    _fingerprintCopyTokens(&subCtx, ctx, "node");
+  }
+  if (node->sortby_dir != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->sortby_dir);
+    _fingerprintString(ctx, "sortby_dir");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->sortby_nulls != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->sortby_nulls);
+    _fingerprintString(ctx, "sortby_nulls");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->useOp != NULL && node->useOp->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->useOp, "useOp");
+    _fingerprintCopyTokens(&subCtx, ctx, "useOp");
+  }
+}
+
+static void
+_fingerprintWindowDef(FingerprintContext *ctx, const WindowDef *node, const char *field_name)
+{
+  _fingerprintString(ctx, "WindowDef");
+  if (node->endOffset != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->endOffset, "endOffset");
+    _fingerprintCopyTokens(&subCtx, ctx, "endOffset");
+  }
+  if (node->frameOptions != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->frameOptions);
+    _fingerprintString(ctx, "frameOptions");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+
+  if (node->name != NULL) {
+    _fingerprintString(ctx, "name");
+    _fingerprintString(ctx, node->name);
+  }
+
+  if (node->orderClause != NULL && node->orderClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->orderClause, "orderClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "orderClause");
+  }
+  if (node->partitionClause != NULL && node->partitionClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->partitionClause, "partitionClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "partitionClause");
+  }
+
+  if (node->refname != NULL) {
+    _fingerprintString(ctx, "refname");
+    _fingerprintString(ctx, node->refname);
+  }
+
+  if (node->startOffset != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->startOffset, "startOffset");
+    _fingerprintCopyTokens(&subCtx, ctx, "startOffset");
+  }
+}
+
+static void
+_fingerprintRangeSubselect(FingerprintContext *ctx, const RangeSubselect *node, const char *field_name)
+{
+  _fingerprintString(ctx, "RangeSubselect");
+  if (node->alias != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->alias, "alias");
+    _fingerprintCopyTokens(&subCtx, ctx, "alias");
+  }
+
+  if (node->lateral) {    _fingerprintString(ctx, "lateral");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->subquery != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->subquery, "subquery");
+    _fingerprintCopyTokens(&subCtx, ctx, "subquery");
+  }
+}
+
+static void
+_fingerprintRangeFunction(FingerprintContext *ctx, const RangeFunction *node, const char *field_name)
+{
+  _fingerprintString(ctx, "RangeFunction");
+  if (node->alias != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->alias, "alias");
+    _fingerprintCopyTokens(&subCtx, ctx, "alias");
+  }
+  if (node->coldeflist != NULL && node->coldeflist->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->coldeflist, "coldeflist");
+    _fingerprintCopyTokens(&subCtx, ctx, "coldeflist");
+  }
+  if (node->functions != NULL && node->functions->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->functions, "functions");
+    _fingerprintCopyTokens(&subCtx, ctx, "functions");
+  }
+
+  if (node->is_rowsfrom) {    _fingerprintString(ctx, "is_rowsfrom");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->lateral) {    _fingerprintString(ctx, "lateral");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->ordinality) {    _fingerprintString(ctx, "ordinality");
+    _fingerprintString(ctx, "true");
+  }
+
+}
+
+static void
+_fingerprintRangeTableSample(FingerprintContext *ctx, const RangeTableSample *node, const char *field_name)
+{
+  _fingerprintString(ctx, "RangeTableSample");
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->method != NULL && node->method->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->method, "method");
+    _fingerprintCopyTokens(&subCtx, ctx, "method");
+  }
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+  if (node->repeatable != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->repeatable, "repeatable");
+    _fingerprintCopyTokens(&subCtx, ctx, "repeatable");
+  }
+}
+
+static void
+_fingerprintTypeName(FingerprintContext *ctx, const TypeName *node, const char *field_name)
+{
+  _fingerprintString(ctx, "TypeName");
+  if (node->arrayBounds != NULL && node->arrayBounds->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arrayBounds, "arrayBounds");
+    _fingerprintCopyTokens(&subCtx, ctx, "arrayBounds");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->names != NULL && node->names->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->names, "names");
+    _fingerprintCopyTokens(&subCtx, ctx, "names");
+  }
+
+  if (node->pct_type) {    _fingerprintString(ctx, "pct_type");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->setof) {    _fingerprintString(ctx, "setof");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->typeOid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->typeOid);
+    _fingerprintString(ctx, "typeOid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->typemod != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->typemod);
+    _fingerprintString(ctx, "typemod");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->typmods != NULL && node->typmods->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->typmods, "typmods");
+    _fingerprintCopyTokens(&subCtx, ctx, "typmods");
+  }
+}
+
+static void
+_fingerprintColumnDef(FingerprintContext *ctx, const ColumnDef *node, const char *field_name)
+{
+  _fingerprintString(ctx, "ColumnDef");
+  if (node->collClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->collClause, "collClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "collClause");
+  }
+  if (node->collOid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->collOid);
+    _fingerprintString(ctx, "collOid");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->colname != NULL) {
+    _fingerprintString(ctx, "colname");
+    _fingerprintString(ctx, node->colname);
+  }
+
+  if (node->constraints != NULL && node->constraints->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->constraints, "constraints");
+    _fingerprintCopyTokens(&subCtx, ctx, "constraints");
+  }
+  if (node->cooked_default != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->cooked_default, "cooked_default");
+    _fingerprintCopyTokens(&subCtx, ctx, "cooked_default");
+  }
+  if (node->fdwoptions != NULL && node->fdwoptions->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->fdwoptions, "fdwoptions");
+    _fingerprintCopyTokens(&subCtx, ctx, "fdwoptions");
+  }
+  if (node->inhcount != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->inhcount);
+    _fingerprintString(ctx, "inhcount");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->is_from_type) {    _fingerprintString(ctx, "is_from_type");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->is_local) {    _fingerprintString(ctx, "is_local");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->is_not_null) {    _fingerprintString(ctx, "is_not_null");
+    _fingerprintString(ctx, "true");
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->raw_default != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->raw_default, "raw_default");
+    _fingerprintCopyTokens(&subCtx, ctx, "raw_default");
+  }
+  if (node->storage != 0) {
+    char str[2] = {node->storage, '\0'};
+    _fingerprintString(ctx, "storage");
+    _fingerprintString(ctx, str);
+  }
+
+  if (node->typeName != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->typeName, "typeName");
+    _fingerprintCopyTokens(&subCtx, ctx, "typeName");
+  }
+}
+
+static void
+_fingerprintIndexElem(FingerprintContext *ctx, const IndexElem *node, const char *field_name)
+{
+  _fingerprintString(ctx, "IndexElem");
+  if (node->collation != NULL && node->collation->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->collation, "collation");
+    _fingerprintCopyTokens(&subCtx, ctx, "collation");
+  }
+  if (node->expr != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->expr, "expr");
+    _fingerprintCopyTokens(&subCtx, ctx, "expr");
+  }
+
+  if (node->indexcolname != NULL) {
+    _fingerprintString(ctx, "indexcolname");
+    _fingerprintString(ctx, node->indexcolname);
+  }
+
+
+  if (node->name != NULL) {
+    _fingerprintString(ctx, "name");
+    _fingerprintString(ctx, node->name);
+  }
+
+  if (node->nulls_ordering != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->nulls_ordering);
+    _fingerprintString(ctx, "nulls_ordering");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->opclass != NULL && node->opclass->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->opclass, "opclass");
+    _fingerprintCopyTokens(&subCtx, ctx, "opclass");
+  }
+  if (node->ordering != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->ordering);
+    _fingerprintString(ctx, "ordering");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintConstraint(FingerprintContext *ctx, const Constraint *node, const char *field_name)
+{
+  _fingerprintString(ctx, "Constraint");
+
+  if (node->access_method != NULL) {
+    _fingerprintString(ctx, "access_method");
+    _fingerprintString(ctx, node->access_method);
+  }
+
+
+  if (node->conname != NULL) {
+    _fingerprintString(ctx, "conname");
+    _fingerprintString(ctx, node->conname);
+  }
+
+  if (node->contype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->contype);
+    _fingerprintString(ctx, "contype");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->cooked_expr != NULL) {
+    _fingerprintString(ctx, "cooked_expr");
+    _fingerprintString(ctx, node->cooked_expr);
+  }
+
+
+  if (node->deferrable) {    _fingerprintString(ctx, "deferrable");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->exclusions != NULL && node->exclusions->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->exclusions, "exclusions");
+    _fingerprintCopyTokens(&subCtx, ctx, "exclusions");
+  }
+  if (node->fk_attrs != NULL && node->fk_attrs->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->fk_attrs, "fk_attrs");
+    _fingerprintCopyTokens(&subCtx, ctx, "fk_attrs");
+  }
+  if (node->fk_del_action != 0) {
+    char str[2] = {node->fk_del_action, '\0'};
+    _fingerprintString(ctx, "fk_del_action");
+    _fingerprintString(ctx, str);
+  }
+
+  if (node->fk_matchtype != 0) {
+    char str[2] = {node->fk_matchtype, '\0'};
+    _fingerprintString(ctx, "fk_matchtype");
+    _fingerprintString(ctx, str);
+  }
+
+  if (node->fk_upd_action != 0) {
+    char str[2] = {node->fk_upd_action, '\0'};
+    _fingerprintString(ctx, "fk_upd_action");
+    _fingerprintString(ctx, str);
+  }
+
+
+  if (node->indexname != NULL) {
+    _fingerprintString(ctx, "indexname");
+    _fingerprintString(ctx, node->indexname);
+  }
+
+
+  if (node->indexspace != NULL) {
+    _fingerprintString(ctx, "indexspace");
+    _fingerprintString(ctx, node->indexspace);
+  }
+
+
+  if (node->initdeferred) {    _fingerprintString(ctx, "initdeferred");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->initially_valid) {    _fingerprintString(ctx, "initially_valid");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->is_no_inherit) {    _fingerprintString(ctx, "is_no_inherit");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->keys != NULL && node->keys->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->keys, "keys");
+    _fingerprintCopyTokens(&subCtx, ctx, "keys");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->old_conpfeqop != NULL && node->old_conpfeqop->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->old_conpfeqop, "old_conpfeqop");
+    _fingerprintCopyTokens(&subCtx, ctx, "old_conpfeqop");
+  }
+  if (node->old_pktable_oid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->old_pktable_oid);
+    _fingerprintString(ctx, "old_pktable_oid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->options != NULL && node->options->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->options, "options");
+    _fingerprintCopyTokens(&subCtx, ctx, "options");
+  }
+  if (node->pk_attrs != NULL && node->pk_attrs->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->pk_attrs, "pk_attrs");
+    _fingerprintCopyTokens(&subCtx, ctx, "pk_attrs");
+  }
+  if (node->pktable != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->pktable, "pktable");
+    _fingerprintCopyTokens(&subCtx, ctx, "pktable");
+  }
+  if (node->raw_expr != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->raw_expr, "raw_expr");
+    _fingerprintCopyTokens(&subCtx, ctx, "raw_expr");
+  }
+
+  if (node->skip_validation) {    _fingerprintString(ctx, "skip_validation");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->where_clause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->where_clause, "where_clause");
+    _fingerprintCopyTokens(&subCtx, ctx, "where_clause");
+  }
+}
+
+static void
+_fingerprintDefElem(FingerprintContext *ctx, const DefElem *node, const char *field_name)
+{
+  _fingerprintString(ctx, "DefElem");
+  if (node->arg != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->arg, "arg");
+    _fingerprintCopyTokens(&subCtx, ctx, "arg");
+  }
+  if (node->defaction != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->defaction);
+    _fingerprintString(ctx, "defaction");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->defname != NULL) {
+    _fingerprintString(ctx, "defname");
+    _fingerprintString(ctx, node->defname);
+  }
+
+
+  if (node->defnamespace != NULL) {
+    _fingerprintString(ctx, "defnamespace");
+    _fingerprintString(ctx, node->defnamespace);
+  }
+
+}
+
+static void
+_fingerprintRangeTblEntry(FingerprintContext *ctx, const RangeTblEntry *node, const char *field_name)
+{
+  _fingerprintString(ctx, "RangeTblEntry");
+  if (node->alias != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->alias, "alias");
+    _fingerprintCopyTokens(&subCtx, ctx, "alias");
+  }
+  if (node->checkAsUser != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->checkAsUser);
+    _fingerprintString(ctx, "checkAsUser");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->ctecolcollations != NULL && node->ctecolcollations->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->ctecolcollations, "ctecolcollations");
+    _fingerprintCopyTokens(&subCtx, ctx, "ctecolcollations");
+  }
+  if (node->ctecoltypes != NULL && node->ctecoltypes->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->ctecoltypes, "ctecoltypes");
+    _fingerprintCopyTokens(&subCtx, ctx, "ctecoltypes");
+  }
+  if (node->ctecoltypmods != NULL && node->ctecoltypmods->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->ctecoltypmods, "ctecoltypmods");
+    _fingerprintCopyTokens(&subCtx, ctx, "ctecoltypmods");
+  }
+  if (node->ctelevelsup != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->ctelevelsup);
+    _fingerprintString(ctx, "ctelevelsup");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->ctename != NULL) {
+    _fingerprintString(ctx, "ctename");
+    _fingerprintString(ctx, node->ctename);
+  }
+
+  if (node->eref != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->eref, "eref");
+    _fingerprintCopyTokens(&subCtx, ctx, "eref");
+  }
+
+  if (node->funcordinality) {    _fingerprintString(ctx, "funcordinality");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->functions != NULL && node->functions->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->functions, "functions");
+    _fingerprintCopyTokens(&subCtx, ctx, "functions");
+  }
+
+  if (node->inFromCl) {    _fingerprintString(ctx, "inFromCl");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->inh) {    _fingerprintString(ctx, "inh");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (true) {
+    int x;
+    Bitmapset	*bms = bms_copy(node->insertedCols);
+
+    _fingerprintString(ctx, "insertedCols");
+
+  	while ((x = bms_first_member(bms)) >= 0) {
+      char buffer[50];
+      sprintf(buffer, "%d", x);
+      _fingerprintString(ctx, buffer);
+    }
+
+    bms_free(bms);
+  }
+  if (node->joinaliasvars != NULL && node->joinaliasvars->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->joinaliasvars, "joinaliasvars");
+    _fingerprintCopyTokens(&subCtx, ctx, "joinaliasvars");
+  }
+  if (node->jointype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->jointype);
+    _fingerprintString(ctx, "jointype");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->lateral) {    _fingerprintString(ctx, "lateral");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->relid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->relid);
+    _fingerprintString(ctx, "relid");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->relkind != 0) {
+    char str[2] = {node->relkind, '\0'};
+    _fingerprintString(ctx, "relkind");
+    _fingerprintString(ctx, str);
+  }
+
+  if (node->requiredPerms != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->requiredPerms);
+    _fingerprintString(ctx, "requiredPerms");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->rtekind != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->rtekind);
+    _fingerprintString(ctx, "rtekind");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->securityQuals != NULL && node->securityQuals->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->securityQuals, "securityQuals");
+    _fingerprintCopyTokens(&subCtx, ctx, "securityQuals");
+  }
+
+  if (node->security_barrier) {    _fingerprintString(ctx, "security_barrier");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (true) {
+    int x;
+    Bitmapset	*bms = bms_copy(node->selectedCols);
+
+    _fingerprintString(ctx, "selectedCols");
+
+  	while ((x = bms_first_member(bms)) >= 0) {
+      char buffer[50];
+      sprintf(buffer, "%d", x);
+      _fingerprintString(ctx, buffer);
+    }
+
+    bms_free(bms);
+  }
+
+  if (node->self_reference) {    _fingerprintString(ctx, "self_reference");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->subquery != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->subquery, "subquery");
+    _fingerprintCopyTokens(&subCtx, ctx, "subquery");
+  }
+  if (node->tablesample != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->tablesample, "tablesample");
+    _fingerprintCopyTokens(&subCtx, ctx, "tablesample");
+  }
+  if (true) {
+    int x;
+    Bitmapset	*bms = bms_copy(node->updatedCols);
+
+    _fingerprintString(ctx, "updatedCols");
+
+  	while ((x = bms_first_member(bms)) >= 0) {
+      char buffer[50];
+      sprintf(buffer, "%d", x);
+      _fingerprintString(ctx, buffer);
+    }
+
+    bms_free(bms);
+  }
+  if (node->values_collations != NULL && node->values_collations->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->values_collations, "values_collations");
+    _fingerprintCopyTokens(&subCtx, ctx, "values_collations");
+  }
+  if (node->values_lists != NULL && node->values_lists->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->values_lists, "values_lists");
+    _fingerprintCopyTokens(&subCtx, ctx, "values_lists");
+  }
+}
+
+static void
+_fingerprintRangeTblFunction(FingerprintContext *ctx, const RangeTblFunction *node, const char *field_name)
+{
+  _fingerprintString(ctx, "RangeTblFunction");
+  if (node->funccolcollations != NULL && node->funccolcollations->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->funccolcollations, "funccolcollations");
+    _fingerprintCopyTokens(&subCtx, ctx, "funccolcollations");
+  }
+  if (node->funccolcount != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->funccolcount);
+    _fingerprintString(ctx, "funccolcount");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->funccolnames != NULL && node->funccolnames->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->funccolnames, "funccolnames");
+    _fingerprintCopyTokens(&subCtx, ctx, "funccolnames");
+  }
+  if (node->funccoltypes != NULL && node->funccoltypes->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->funccoltypes, "funccoltypes");
+    _fingerprintCopyTokens(&subCtx, ctx, "funccoltypes");
+  }
+  if (node->funccoltypmods != NULL && node->funccoltypmods->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->funccoltypmods, "funccoltypmods");
+    _fingerprintCopyTokens(&subCtx, ctx, "funccoltypmods");
+  }
+  if (node->funcexpr != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->funcexpr, "funcexpr");
+    _fingerprintCopyTokens(&subCtx, ctx, "funcexpr");
+  }
+  if (true) {
+    int x;
+    Bitmapset	*bms = bms_copy(node->funcparams);
+
+    _fingerprintString(ctx, "funcparams");
+
+  	while ((x = bms_first_member(bms)) >= 0) {
+      char buffer[50];
+      sprintf(buffer, "%d", x);
+      _fingerprintString(ctx, buffer);
+    }
+
+    bms_free(bms);
+  }
+}
+
+static void
+_fingerprintTableSampleClause(FingerprintContext *ctx, const TableSampleClause *node, const char *field_name)
+{
+  _fingerprintString(ctx, "TableSampleClause");
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->repeatable != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->repeatable, "repeatable");
+    _fingerprintCopyTokens(&subCtx, ctx, "repeatable");
+  }
+  if (node->tsmhandler != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->tsmhandler);
+    _fingerprintString(ctx, "tsmhandler");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintWithCheckOption(FingerprintContext *ctx, const WithCheckOption *node, const char *field_name)
+{
+  _fingerprintString(ctx, "WithCheckOption");
+
+  if (node->cascaded) {    _fingerprintString(ctx, "cascaded");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->kind != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->kind);
+    _fingerprintString(ctx, "kind");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->polname != NULL) {
+    _fingerprintString(ctx, "polname");
+    _fingerprintString(ctx, node->polname);
+  }
+
+  if (node->qual != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->qual, "qual");
+    _fingerprintCopyTokens(&subCtx, ctx, "qual");
+  }
+
+  if (node->relname != NULL) {
+    _fingerprintString(ctx, "relname");
+    _fingerprintString(ctx, node->relname);
+  }
+
+}
+
+static void
+_fingerprintSortGroupClause(FingerprintContext *ctx, const SortGroupClause *node, const char *field_name)
+{
+  _fingerprintString(ctx, "SortGroupClause");
+  if (node->eqop != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->eqop);
+    _fingerprintString(ctx, "eqop");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->hashable) {    _fingerprintString(ctx, "hashable");
+    _fingerprintString(ctx, "true");
+  }
+
+
+  if (node->nulls_first) {    _fingerprintString(ctx, "nulls_first");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->sortop != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->sortop);
+    _fingerprintString(ctx, "sortop");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->tleSortGroupRef != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->tleSortGroupRef);
+    _fingerprintString(ctx, "tleSortGroupRef");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintGroupingSet(FingerprintContext *ctx, const GroupingSet *node, const char *field_name)
+{
+  _fingerprintString(ctx, "GroupingSet");
+  if (node->content != NULL && node->content->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->content, "content");
+    _fingerprintCopyTokens(&subCtx, ctx, "content");
+  }
+  if (node->kind != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->kind);
+    _fingerprintString(ctx, "kind");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+}
+
+static void
+_fingerprintWindowClause(FingerprintContext *ctx, const WindowClause *node, const char *field_name)
+{
+  _fingerprintString(ctx, "WindowClause");
+
+  if (node->copiedOrder) {    _fingerprintString(ctx, "copiedOrder");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->endOffset != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->endOffset, "endOffset");
+    _fingerprintCopyTokens(&subCtx, ctx, "endOffset");
+  }
+  if (node->frameOptions != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->frameOptions);
+    _fingerprintString(ctx, "frameOptions");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->name != NULL) {
+    _fingerprintString(ctx, "name");
+    _fingerprintString(ctx, node->name);
+  }
+
+  if (node->orderClause != NULL && node->orderClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->orderClause, "orderClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "orderClause");
+  }
+  if (node->partitionClause != NULL && node->partitionClause->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->partitionClause, "partitionClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "partitionClause");
+  }
+
+  if (node->refname != NULL) {
+    _fingerprintString(ctx, "refname");
+    _fingerprintString(ctx, node->refname);
+  }
+
+  if (node->startOffset != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->startOffset, "startOffset");
+    _fingerprintCopyTokens(&subCtx, ctx, "startOffset");
+  }
+  if (node->winref != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->winref);
+    _fingerprintString(ctx, "winref");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintFuncWithArgs(FingerprintContext *ctx, const FuncWithArgs *node, const char *field_name)
+{
+  _fingerprintString(ctx, "FuncWithArgs");
+  if (node->funcargs != NULL && node->funcargs->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->funcargs, "funcargs");
+    _fingerprintCopyTokens(&subCtx, ctx, "funcargs");
+  }
+  if (node->funcname != NULL && node->funcname->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->funcname, "funcname");
+    _fingerprintCopyTokens(&subCtx, ctx, "funcname");
+  }
+}
+
+static void
+_fingerprintAccessPriv(FingerprintContext *ctx, const AccessPriv *node, const char *field_name)
+{
+  _fingerprintString(ctx, "AccessPriv");
+  if (node->cols != NULL && node->cols->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->cols, "cols");
+    _fingerprintCopyTokens(&subCtx, ctx, "cols");
+  }
+
+  if (node->priv_name != NULL) {
+    _fingerprintString(ctx, "priv_name");
+    _fingerprintString(ctx, node->priv_name);
+  }
+
+}
+
+static void
+_fingerprintCreateOpClassItem(FingerprintContext *ctx, const CreateOpClassItem *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CreateOpClassItem");
+  if (node->args != NULL && node->args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->args, "args");
+    _fingerprintCopyTokens(&subCtx, ctx, "args");
+  }
+  if (node->class_args != NULL && node->class_args->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->class_args, "class_args");
+    _fingerprintCopyTokens(&subCtx, ctx, "class_args");
+  }
+  if (node->itemtype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->itemtype);
+    _fingerprintString(ctx, "itemtype");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->name != NULL && node->name->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->name, "name");
+    _fingerprintCopyTokens(&subCtx, ctx, "name");
+  }
+  if (node->number != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->number);
+    _fingerprintString(ctx, "number");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->order_family != NULL && node->order_family->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->order_family, "order_family");
+    _fingerprintCopyTokens(&subCtx, ctx, "order_family");
+  }
+  if (node->storedtype != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->storedtype, "storedtype");
+    _fingerprintCopyTokens(&subCtx, ctx, "storedtype");
+  }
+}
+
+static void
+_fingerprintTableLikeClause(FingerprintContext *ctx, const TableLikeClause *node, const char *field_name)
+{
+  _fingerprintString(ctx, "TableLikeClause");
+  if (node->options != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->options);
+    _fingerprintString(ctx, "options");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->relation != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->relation, "relation");
+    _fingerprintCopyTokens(&subCtx, ctx, "relation");
+  }
+}
+
+static void
+_fingerprintFunctionParameter(FingerprintContext *ctx, const FunctionParameter *node, const char *field_name)
+{
+  _fingerprintString(ctx, "FunctionParameter");
+  if (node->argType != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->argType, "argType");
+    _fingerprintCopyTokens(&subCtx, ctx, "argType");
+  }
+  if (node->defexpr != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->defexpr, "defexpr");
+    _fingerprintCopyTokens(&subCtx, ctx, "defexpr");
+  }
+  if (node->mode != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->mode);
+    _fingerprintString(ctx, "mode");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->name != NULL) {
+    _fingerprintString(ctx, "name");
+    _fingerprintString(ctx, node->name);
+  }
+
+}
+
+static void
+_fingerprintLockingClause(FingerprintContext *ctx, const LockingClause *node, const char *field_name)
+{
+  _fingerprintString(ctx, "LockingClause");
+  if (node->lockedRels != NULL && node->lockedRels->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->lockedRels, "lockedRels");
+    _fingerprintCopyTokens(&subCtx, ctx, "lockedRels");
+  }
+  if (node->strength != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->strength);
+    _fingerprintString(ctx, "strength");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->waitPolicy != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->waitPolicy);
+    _fingerprintString(ctx, "waitPolicy");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintRowMarkClause(FingerprintContext *ctx, const RowMarkClause *node, const char *field_name)
+{
+  _fingerprintString(ctx, "RowMarkClause");
+
+  if (node->pushedDown) {    _fingerprintString(ctx, "pushedDown");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->rti != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->rti);
+    _fingerprintString(ctx, "rti");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->strength != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->strength);
+    _fingerprintString(ctx, "strength");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->waitPolicy != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->waitPolicy);
+    _fingerprintString(ctx, "waitPolicy");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintXmlSerialize(FingerprintContext *ctx, const XmlSerialize *node, const char *field_name)
+{
+  _fingerprintString(ctx, "XmlSerialize");
+  if (node->expr != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->expr, "expr");
+    _fingerprintCopyTokens(&subCtx, ctx, "expr");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->typeName != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->typeName, "typeName");
+    _fingerprintCopyTokens(&subCtx, ctx, "typeName");
+  }
+  if (node->xmloption != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->xmloption);
+    _fingerprintString(ctx, "xmloption");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintWithClause(FingerprintContext *ctx, const WithClause *node, const char *field_name)
+{
+  _fingerprintString(ctx, "WithClause");
+  if (node->ctes != NULL && node->ctes->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->ctes, "ctes");
+    _fingerprintCopyTokens(&subCtx, ctx, "ctes");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+
+  if (node->recursive) {    _fingerprintString(ctx, "recursive");
+    _fingerprintString(ctx, "true");
+  }
+
+}
+
+static void
+_fingerprintInferClause(FingerprintContext *ctx, const InferClause *node, const char *field_name)
+{
+  _fingerprintString(ctx, "InferClause");
+
+  if (node->conname != NULL) {
+    _fingerprintString(ctx, "conname");
+    _fingerprintString(ctx, node->conname);
+  }
+
+  if (node->indexElems != NULL && node->indexElems->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->indexElems, "indexElems");
+    _fingerprintCopyTokens(&subCtx, ctx, "indexElems");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->whereClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->whereClause, "whereClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "whereClause");
+  }
+}
+
+static void
+_fingerprintOnConflictClause(FingerprintContext *ctx, const OnConflictClause *node, const char *field_name)
+{
+  _fingerprintString(ctx, "OnConflictClause");
+  if (node->action != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->action);
+    _fingerprintString(ctx, "action");
+    _fingerprintString(ctx, buffer);
+  }
+
+  if (node->infer != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->infer, "infer");
+    _fingerprintCopyTokens(&subCtx, ctx, "infer");
+  }
+  // Intentionally ignoring node->location for fingerprinting
+  if (node->targetList != NULL && node->targetList->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->targetList, "targetList");
+    _fingerprintCopyTokens(&subCtx, ctx, "targetList");
+  }
+  if (node->whereClause != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->whereClause, "whereClause");
+    _fingerprintCopyTokens(&subCtx, ctx, "whereClause");
+  }
+}
+
+static void
+_fingerprintCommonTableExpr(FingerprintContext *ctx, const CommonTableExpr *node, const char *field_name)
+{
+  _fingerprintString(ctx, "CommonTableExpr");
+  if (node->aliascolnames != NULL && node->aliascolnames->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->aliascolnames, "aliascolnames");
+    _fingerprintCopyTokens(&subCtx, ctx, "aliascolnames");
+  }
+  if (node->ctecolcollations != NULL && node->ctecolcollations->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->ctecolcollations, "ctecolcollations");
+    _fingerprintCopyTokens(&subCtx, ctx, "ctecolcollations");
+  }
+  if (node->ctecolnames != NULL && node->ctecolnames->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->ctecolnames, "ctecolnames");
+    _fingerprintCopyTokens(&subCtx, ctx, "ctecolnames");
+  }
+  if (node->ctecoltypes != NULL && node->ctecoltypes->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->ctecoltypes, "ctecoltypes");
+    _fingerprintCopyTokens(&subCtx, ctx, "ctecoltypes");
+  }
+  if (node->ctecoltypmods != NULL && node->ctecoltypmods->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->ctecoltypmods, "ctecoltypmods");
+    _fingerprintCopyTokens(&subCtx, ctx, "ctecoltypmods");
+  }
+
+  if (node->ctename != NULL) {
+    _fingerprintString(ctx, "ctename");
+    _fingerprintString(ctx, node->ctename);
+  }
+
+  if (node->ctequery != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->ctequery, "ctequery");
+    _fingerprintCopyTokens(&subCtx, ctx, "ctequery");
+  }
+
+  if (node->cterecursive) {    _fingerprintString(ctx, "cterecursive");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->cterefcount != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->cterefcount);
+    _fingerprintString(ctx, "cterefcount");
+    _fingerprintString(ctx, buffer);
+  }
+
+  // Intentionally ignoring node->location for fingerprinting
+}
+
+static void
+_fingerprintRoleSpec(FingerprintContext *ctx, const RoleSpec *node, const char *field_name)
+{
+  _fingerprintString(ctx, "RoleSpec");
+  // Intentionally ignoring node->location for fingerprinting
+
+  if (node->rolename != NULL) {
+    _fingerprintString(ctx, "rolename");
+    _fingerprintString(ctx, node->rolename);
+  }
+
+  if (node->roletype != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->roletype);
+    _fingerprintString(ctx, "roletype");
+    _fingerprintString(ctx, buffer);
+  }
+
+}
+
+static void
+_fingerprintInlineCodeBlock(FingerprintContext *ctx, const InlineCodeBlock *node, const char *field_name)
+{
+  _fingerprintString(ctx, "InlineCodeBlock");
+
+  if (node->langIsTrusted) {    _fingerprintString(ctx, "langIsTrusted");
+    _fingerprintString(ctx, "true");
+  }
+
+  if (node->langOid != 0) {
+    char buffer[50];
+    sprintf(buffer, "%d", node->langOid);
+    _fingerprintString(ctx, "langOid");
+    _fingerprintString(ctx, buffer);
+  }
+
+
+  if (node->source_text != NULL) {
+    _fingerprintString(ctx, "source_text");
+    _fingerprintString(ctx, node->source_text);
+  }
+
+}
+

--- a/scripts/generate_fingerprint_outfuncs.rb
+++ b/scripts/generate_fingerprint_outfuncs.rb
@@ -1,0 +1,240 @@
+#!/usr/bin/env ruby
+
+# rubocop:disable Metrics/AbcSize, Metrics/LineLength, Metrics/MethodLength, Style/WordArray, Metrics/ClassLength, Style/Documentation, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Style/MutableConstant, Style/TrailingCommaInLiteral
+
+require 'bundler'
+require 'json'
+
+class Generator
+  def initialize
+    @nodetypes = JSON.parse(File.read('./srcdata/nodetypes.json'))
+    @struct_defs = JSON.parse(File.read('./srcdata/struct_defs.json'))
+    @enum_defs = JSON.parse(File.read('./srcdata/enum_defs.json'))
+    @typedefs = JSON.parse(File.read('./srcdata/typedefs.json'))
+    @all_known_enums = JSON.parse(File.read('./srcdata/all_known_enums.json'))
+  end
+
+  FINGERPRINT_RES_TARGET_NAME = <<-EOL
+  if (node->name != NULL && (field_name == NULL || strcmp(field_name, "targetList") != 0)) {
+    _fingerprintString(ctx, "name");
+    _fingerprintString(ctx, node->name);
+  }
+EOL
+
+  FINGERPRINT_NODE = <<-EOL
+  if (true) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, &node->%<name>s, "%<name>s");
+    _fingerprintCopyTokens(&subCtx, ctx, "%<name>s");
+  }
+EOL
+
+  FINGERPRINT_NODE_PTR = <<-EOL
+  if (node->%<name>s != NULL) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->%<name>s, "%<name>s");
+    _fingerprintCopyTokens(&subCtx, ctx, "%<name>s");
+  }
+EOL
+
+  FINGERPRINT_LIST = <<-EOL
+  if (node->%<name>s != NULL && node->%<name>s->length > 0) {
+    FingerprintContext subCtx;
+    _fingerprintInitForTokens(&subCtx);
+    _fingerprintNode(&subCtx, node->%<name>s, "%<name>s");
+    _fingerprintCopyTokens(&subCtx, ctx, "%<name>s");
+  }
+EOL
+
+  FINGERPRINT_INT = <<-EOL
+  if (node->%<name>s != 0) {
+    char buffer[50];
+    sprintf(buffer, "%%d", node->%<name>s);
+    _fingerprintString(ctx, "%<name>s");
+    _fingerprintString(ctx, buffer);
+  }
+
+EOL
+
+  FINGERPRINT_LONG_INT = <<-EOL
+  if (node->%<name>s != 0) {
+    char buffer[50];
+    sprintf(buffer, "%%ld", node->%<name>s);
+    _fingerprintString(ctx, "%<name>s");
+    _fingerprintString(ctx, buffer);
+  }
+
+EOL
+
+  FINGERPRINT_FLOAT = <<-EOL
+if (node->%<name>s != 0) {
+  char buffer[50];
+  sprintf(buffer, "%%f", node->%<name>s);
+  _fingerprintString(ctx, "%<name>s");
+  _fingerprintString(ctx, buffer);
+}
+
+EOL
+
+  FINGERPRINT_INT_ARRAY = <<-EOL
+  if (true) {
+    int x;
+    Bitmapset	*bms = bms_copy(node->%<name>s);
+
+    _fingerprintString(ctx, "%<name>s");
+
+  	while ((x = bms_first_member(bms)) >= 0) {
+      char buffer[50];
+      sprintf(buffer, "%%d", x);
+      _fingerprintString(ctx, buffer);
+    }
+
+    bms_free(bms);
+  }
+EOL
+
+  # Fingerprinting additional code to be inserted
+  FINGERPRINT_OVERRIDE_NODES = {
+    'A_Const' => :skip,
+    'Alias' => :skip,
+    'ParamRef' => :skip,
+    'SetToDefault' => :skip,
+  }
+  FINGERPRINT_OVERRIDE_FIELDS = {
+    [nil, 'location'] => :skip,
+    ['ResTarget', 'name'] => FINGERPRINT_RES_TARGET_NAME,
+    ['PrepareStmt', 'name'] => :skip,
+    ['ExecuteStmt', 'name'] => :skip,
+    ['DeallocateStmt', 'name'] => :skip,
+  }
+  INT_TYPES = ['bits32', 'uint32', 'int', 'Oid', 'int32', 'Index', 'AclMode', 'int16', 'AttrNumber', 'uint16']
+  LONG_INT_TYPES = ['long']
+  INT_ARRAY_TYPES = ['Bitmapset*', 'Bitmapset', 'Relids']
+  FLOAT_TYPES = ['Cost']
+
+  IGNORE_FOR_GENERATOR = ['Integer', 'Float', 'String', 'BitString', 'Null', 'IntList', 'OidList', 'List']
+
+  def generate_fingerprint_defs!
+    @fingerprint_defs = {}
+
+    ['nodes/parsenodes', 'nodes/primnodes'].each do |group|
+      @struct_defs[group].each do |type, struct_def|
+        next if struct_def['fields'].nil?
+        next if IGNORE_FOR_GENERATOR.include?(type)
+
+        fp_override = FINGERPRINT_OVERRIDE_NODES[type]
+        if fp_override
+          fp_override = "  // Intentionally ignoring all fields for fingerprinting\n" if fp_override == :skip
+          fingerprint_def = fp_override
+        else
+          fingerprint_def = format("  _fingerprintString(ctx, \"%s\");\n", type)
+          struct_def['fields'].reject { |f| f['name'].nil? }.sort_by { |f| f['name'] }.each do |field|
+            name = field['name']
+            field_type = field['c_type']
+
+            fp_override = FINGERPRINT_OVERRIDE_FIELDS[[type, field['name']]] || FINGERPRINT_OVERRIDE_FIELDS[[nil, field['name']]]
+            if fp_override
+              if fp_override == :skip
+                fp_override = format("  // Intentionally ignoring node->%s for fingerprinting\n", name)
+              end
+              fingerprint_def += fp_override
+              next
+            end
+
+            case field_type
+            # when '[][]Node'
+            #  fingerprint_def += format(FINGERPRINT_NODE_ARRAY_ARRAY, name: name)
+            # when '[]Node'
+            #  fingerprint_def += format(FINGERPRINT_NODE_ARRAY, name: name)
+            when 'Node'
+              fingerprint_def += format(FINGERPRINT_NODE, name: name)
+            when 'Node*', 'Expr*'
+              fingerprint_def += format(FINGERPRINT_NODE_PTR, name: name)
+            when 'List*'
+              fingerprint_def += format(FINGERPRINT_LIST, name: name)
+            when 'CreateStmt'
+              fingerprint_def += format("  _fingerprintString(ctx, \"%s\");\n", name)
+              fingerprint_def += format("  _fingerprintNode(ctx, &node->%s, \"%s\");\n", name, name)
+            when 'char'
+              fingerprint_def += format("  if (node->%s != 0) {\n", name)
+              fingerprint_def += format("    char str[2] = {node->%s, '\\0'};\n", name)
+              fingerprint_def += format("    _fingerprintString(ctx, \"%s\");\n", name)
+              fingerprint_def += "    _fingerprintString(ctx, str);\n"
+              fingerprint_def += "  }\n\n"
+            when 'string'
+              fingerprint_def += format("  if (strlen(node->%s) > 0) {\n", name)
+              fingerprint_def += format("    _fingerprintString(ctx, \"%s\");\n", name)
+              fingerprint_def += format("    _fingerprintString(ctx, node->%s);\n", name)
+              fingerprint_def += "  }\n\n"
+            when 'char*'
+              fingerprint_def += format("\n  if (node->%s != NULL) {\n", name)
+              fingerprint_def += format("    _fingerprintString(ctx, \"%s\");\n", name)
+              fingerprint_def += format("    _fingerprintString(ctx, node->%s);\n", name)
+              fingerprint_def += "  }\n\n"
+            when 'bool'
+              fingerprint_def += format("\n  if (node->%s) {", name)
+              fingerprint_def += format("    _fingerprintString(ctx, \"%s\");\n", name)
+              fingerprint_def += format("    _fingerprintString(ctx, \"true\");\n")
+              fingerprint_def += "  }\n\n"
+            when 'Datum', 'void*', 'Expr', 'NodeTag'
+              # Ignore
+            when *INT_TYPES
+              fingerprint_def += format(FINGERPRINT_INT, name: name)
+            when *LONG_INT_TYPES
+              fingerprint_def += format(FINGERPRINT_LONG_INT, name: name)
+            when *INT_ARRAY_TYPES
+              fingerprint_def += format(FINGERPRINT_INT_ARRAY, name: name)
+            when *FLOAT_TYPES
+              fingerprint_def += format(FINGERPRINT_FLOAT, name: name)
+            else
+              if field_type.end_with?('*') && @nodetypes.include?(field_type[0..-2])
+                fingerprint_def += format(FINGERPRINT_NODE_PTR, name: name)
+              elsif @all_known_enums.include?(field_type)
+                fingerprint_def += format(FINGERPRINT_INT, name: name)
+              else
+                # This shouldn't happen - if it does the above is missing something :-)
+                puts type
+                puts name
+                puts field_type
+                raise type
+              end
+            end
+          end
+        end
+
+        @fingerprint_defs[type] = fingerprint_def
+      end
+    end
+  end
+
+  def generate!
+    generate_fingerprint_defs!
+
+    defs = ''
+    conds = ''
+
+    @nodetypes.each do |type|
+      # next if IGNORE_LIST.include?(type)
+      fingerprint_def = @fingerprint_defs[type]
+      next unless fingerprint_def
+
+      defs += "static void\n"
+      defs += format("_fingerprint%s(FingerprintContext *ctx, const %s *node, const char *field_name)\n", type, type)
+      defs += "{\n"
+      defs += fingerprint_def
+      defs += "}\n"
+      defs += "\n"
+
+      conds += format("case T_%s:\n", type)
+      conds += format("  _fingerprint%s(ctx, obj, field_name);\n", type)
+      conds += "  break;\n"
+    end
+
+    File.write('./pg_query_fingerprint_defs.c', defs)
+    File.write('./pg_query_fingerprint_conds.c', conds)
+  end
+end
+
+Generator.new.generate!

--- a/scripts/generate_fingerprint_tests.rb
+++ b/scripts/generate_fingerprint_tests.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+
+require 'bundler'
+require 'json'
+
+class Generator
+  def initialize
+    @fingerprint_tests = JSON.parse(File.read('./testdata/fingerprint.json'))
+  end
+
+  def generate!
+    test_lines = []
+
+    @fingerprint_tests.each do |test_def|
+      test_lines << test_def['input']
+      test_lines << test_def['expectedHash']
+    end
+
+    File.write './test/fingerprint_tests.c', <<-EOF
+size_t testCount = #{test_lines.size};
+
+const char* tests[] = {
+#{test_lines.map { |test_line| format('  %s,', test_line.inspect) }.join("\n")}
+};
+EOF
+  end
+end
+
+Generator.new.generate!

--- a/test/fingerprint.c
+++ b/test/fingerprint.c
@@ -1,0 +1,32 @@
+#include <pg_query.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "fingerprint_tests.c"
+
+int main() {
+  size_t i;
+  bool ret_code = 0;
+
+  pg_query_init();
+
+  for (i = 0; i < testCount; i += 2) {
+    PgQueryFingerprintResult result = pg_query_fingerprint(tests[i]);
+
+    if (strcmp(result.hexdigest, tests[i + 1]) == 0) {
+      printf(".");
+    } else {
+      ret_code = -1;
+      printf("INVALID (%s needs to be %s, SQL was: %s)\n", result.hexdigest, tests[i + 1], tests[i]);
+      pg_query_fingerprint_with_opts(tests[i], true);
+    }
+
+    pg_query_free_fingerprint_result(result);
+  }
+
+  printf("\n");
+
+  return ret_code;
+}

--- a/test/fingerprint_tests.c
+++ b/test/fingerprint_tests.c
@@ -1,9 +1,3 @@
-#include <pg_query.h>
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 size_t testCount = 62;
 
 const char* tests[] = {
@@ -16,7 +10,7 @@ const char* tests[] = {
   "SELECT 1; SELECT a FROM b",
   "c8ff78820feae5ed6d7ca580c598f51e25aa2dbe",
   "SELECT COUNT(DISTINCT id), * FROM targets WHERE something IS NOT NULL AND elsewhere::interval < now()",
-  "fbfa0619cd50c64ab1301830e8f3f55d6f1c81ff",
+  "5851b1bbe459c429c3cec0cdd4a136215d0d094e",
   "INSERT INTO test (a, b) VALUES (?, ?)",
   "7987d8bb26ed399b481728a6e8ca1b668f13d93e",
   "INSERT INTO test (b, a) VALUES (?, ?)",
@@ -24,13 +18,13 @@ const char* tests[] = {
   "SELECT b AS x, a AS y FROM z",
   "b3a90446a1b17d7e89f211c28e791f45da72ca8b",
   "SELECT * FROM x WHERE y IN (?)",
-  "68d00e0f1420c03fa1600ddf49455e068f6185c4",
+  "48abd2ae1d24983140acd4998d1c3807eeb6fa80",
   "SELECT * FROM x WHERE y IN (?, ?, ?)",
-  "68d00e0f1420c03fa1600ddf49455e068f6185c4",
+  "48abd2ae1d24983140acd4998d1c3807eeb6fa80",
   "SELECT * FROM x WHERE y IN ( ?::uuid )",
-  "949ab5b077dc2025b9bfc537fdcd678e42d042fd",
+  "84527cd41b9aea7f010b676b3ad5e9a5184a3f87",
   "SELECT * FROM x WHERE y IN ( ?::uuid, ?::uuid, ?::uuid )",
-  "949ab5b077dc2025b9bfc537fdcd678e42d042fd",
+  "84527cd41b9aea7f010b676b3ad5e9a5184a3f87",
   "PREPARE a123 AS SELECT a",
   "0fd9ef315fb2409090b1c6457e3ff581018d3bed",
   "EXECUTE a123",
@@ -42,13 +36,13 @@ const char* tests[] = {
   "EXPLAIN ANALYZE SELECT a",
   "315ff6b68acdf887c8196fd2cb9ee7be506adf36",
   "WITH a AS (SELECT * FROM x WHERE x.y = ? AND x.z = 1) SELECT * FROM a",
-  "fcf2500b7dcb8b030f3f00cb7c4f2dafd0dbca1c",
+  "6b8a833815b466aa7288b942f7a22f2c44cd7ee7",
   "CREATE TABLE types (a float(2), b float(49), c NUMERIC(2, 3), d character(4), e char(5), f varchar(6), g character varying(7))",
   "8b9c10a0987ccba4f8d8263f3fa7e9e8095d6c58",
   "CREATE VIEW view_a (a, b) AS WITH RECURSIVE view_a (a, b) AS (SELECT * FROM a(1)) SELECT \"a\", \"b\" FROM \"view_a\"",
   "c1164d94a613858d257352dc6b7d3998d23cc27e",
   "VACUUM FULL my_table",
-  "764cba2fdeb69c2136c4450280456af1cb0065d5",
+  "a441b9a9c46b2919f4c2b02362a7490347be3a41",
   "SELECT * FROM x AS a, y AS b",
   "449b0e33058c2020cb901507428371e76dd1135c",
   "SELECT * FROM y AS a, x AS b",
@@ -70,26 +64,3 @@ const char* tests[] = {
   "SELECT * FROM a AS b",
   "1f3a0a714c4e3bbf38e9eab45104fe96f7746ab2",
 };
-
-int main() {
-  size_t i;
-
-  pg_query_init();
-
-  for (i = 0; i < testCount; i += 2) {
-    PgQueryFingerprintResult result = pg_query_fingerprint(tests[i]);
-
-    if (strcmp(result.hexdigest, tests[i + 1]) == 0) {
-      printf(".");
-    } else {
-      printf("INVALID (%s needs to be %s, SQL was: %s)\n", result.hexdigest, tests[i + 1], tests[i]);
-      pg_query_fingerprint_with_opts(tests[i], true);
-    }
-
-    pg_query_free_fingerprint_result(result);
-  }
-
-  printf("\n");
-
-  return 0;
-}


### PR DESCRIPTION
## Scope

In an effort to speed up fingerprinting of SQL statements, and synchronize the implementation across languages (see https://github.com/lfittl/pg_query/pull/45), this implements a pure C version of `.fingerprint` from the main pg_query library.

The primary use case for this is when you have a lot of queries you need to store and match with existing DB entries - but it also shows how to build automated traversal across all node types easily.
