### PR TITLE
Escape JSON strings so all characters can be represented.

### DIFF
--- a/pg_query_json.c
+++ b/pg_query_json.c
@@ -107,32 +107,52 @@ removeTrailingDelimiter(StringInfo str)
 }
 
 static void
-_outToken(StringInfo str, const char *s)
+_outToken(StringInfo buf, const char *str)
 {
-	if (s == NULL)
+	if (str == NULL)
 	{
-		appendStringInfoString(str, "null");
+		appendStringInfoString(buf, "null");
 		return;
 	}
 
-	appendStringInfoChar(str, '"');
-	while (*s)
+	// copied directly from https://github.com/postgres/postgres/blob/master/src/backend/utils/adt/json.c#L2428
+	const char *p;
+
+	appendStringInfoCharMacro(buf, '"');
+	for (p = str; *p; p++)
 	{
-		/* These chars must be backslashed anywhere in the string */
-		if (*s == '\n')
-			appendStringInfoString(str, "\\n");
-		else if (*s == '\r')
-			appendStringInfoString(str, "\\r");
-		else if (*s == '\t')
-			appendStringInfoString(str, "\\t");
-		else if (*s == '\\' || *s == '"') {
-			appendStringInfoChar(str, '\\');
-			appendStringInfoChar(str, *s);
-		} else
-			appendStringInfoChar(str, *s);
-		s++;
+		switch (*p)
+		{
+			case '\b':
+				appendStringInfoString(buf, "\\b");
+				break;
+			case '\f':
+				appendStringInfoString(buf, "\\f");
+				break;
+			case '\n':
+				appendStringInfoString(buf, "\\n");
+				break;
+			case '\r':
+				appendStringInfoString(buf, "\\r");
+				break;
+			case '\t':
+				appendStringInfoString(buf, "\\t");
+				break;
+			case '"':
+				appendStringInfoString(buf, "\\\"");
+				break;
+			case '\\':
+				appendStringInfoString(buf, "\\\\");
+				break;
+			default:
+				if ((unsigned char) *p < ' ')
+					appendStringInfo(buf, "\\u%04x", (int) *p);
+				else
+					appendStringInfoCharMacro(buf, *p);
+				break;
+		}
 	}
-	appendStringInfoChar(str, '"');
+	appendStringInfoCharMacro(buf, '"');
 }
 
 static void


### PR DESCRIPTION
This PR fixes a bug where the returned JSON string doesn't correctly encode control characters. It results in certain inputs being unparseable by regular JSON parsers. The simplest way to reproduce is probably just open up `irb` with the ruby gem:

``` ruby
PgQuery.parse "SELECT parse_ident(E'\"c\".X XXXX\002XXXXXX')"
```

The above SQL is from the 9.5.3 regression tests.

This new function was taken directly from the postgres source [here](https://github.com/postgres/postgres/blob/master/src/backend/utils/adt/json.c#L2428). It's basically identical to the `_outToken` we already have except it includes the case for escaping control characters. I figured it'd be best to just use exactly what's in postgres. I first attempted to actually use that exported API except it quickly turned into a rabbit hole of things to drag in because json.c has some server-y stuff in it too. It's pretty unlikely this function to change much so to keep it simple I just copied the function body into the project.

The PR should include a test but I wasn't sure where the tests are being maintained - they look like they're being auto-generated.
