### PR TITLE
Removed references to 128 bit

### DIFF
--- a/src/postgres/include/pg_config.h
+++ b/src/postgres/include/pg_config.h
@@ -721,9 +721,6 @@
 /* Define to the version of this package. */
 #define PACKAGE_VERSION "9.5.3"
 
-/* Define to the name of a signed 128-bit integer type. */
-#define PG_INT128_TYPE __int128
-
 /* Define to the name of a signed 64-bit integer type. */
 #define PG_INT64_TYPE long int
 


### PR DESCRIPTION
This makes it compatible with 32 bit systems. We don't need use support
for 128 bit integers anywhere in the codebase.

An alternative option would be to make this depend on a configure script
(like postgres does to generate pg_config.h), but this seems overkill
given we don't really have need for them.

This fails at my local machine when running the concurrency tests:
```
ERROR creating pthread - pthread_create return code 11
```
which doesn't appear to be related to the change itself. This should fix the problem in #26.