### PR TITLE
Move inclusion of stdio.h in plpgsql parser

### DIFF
--- a/src/pg_query_parse_plpgsql.c
+++ b/src/pg_query_parse_plpgsql.c
@@ -1,3 +1,6 @@
+#define _GNU_SOURCE // Necessary to get asprintf (which is a GNU extension)
+#include <stdio.h>
+
 #include "pg_query.h"
 #include "pg_query_internal.h"
 #include "pg_query_json_plpgsql.h"
@@ -8,9 +11,6 @@
 #include <catalog/pg_proc_fn.h>
 #include <nodes/parsenodes.h>
 #include <nodes/nodeFuncs.h>
-
-#define _GNU_SOURCE // Necessary to get asprintf (which is a GNU extension)
-#include <stdio.h>
 
 typedef struct {
   PLpgSQL_function *func;


### PR DESCRIPTION
We have to define _GNU_SOURCE before we include this file to get access
to asprintf. In case any other inclusion before already included stdio.h
the define line is effectively ignored, which may result in warnings
about calling the undefined method asprintf.

It would have been enough to move the define line to the top, but by
keeping the define and include as close to eachother as possible it's
clearer why it's there.