### PR TITLE
Make sure we have a valid proc_source

### DIFF
--- a/src/pg_query_parse_plpgsql.c
+++ b/src/pg_query_parse_plpgsql.c
@@ -80,7 +80,7 @@ static void plpgsql_compile_error_callback(void *arg)
 static PLpgSQL_function *compile_create_function_stmt(CreateFunctionStmt* stmt)
 {
 	char *func_name;
-    char *proc_source;
+    char *proc_source = NULL;
 	PLpgSQL_function *function;
 	ErrorContextCallback plerrcontext;
 	PLpgSQL_variable *var;
@@ -111,6 +111,8 @@ static PLpgSQL_function *compile_create_function_stmt(CreateFunctionStmt* stmt)
           }
       }
     }
+
+	assert(proc_source);
 
     if (stmt->returnType != NULL) {
         foreach(lc3, stmt->returnType->names)


### PR DESCRIPTION
We assign a value to this variable in an if statement, which means there
might be a chance this value is not initialized, and the compiler warns
about that. Initialize it to NULL, and add an assertion to make sure we
don't pass NULL to plpgsql_scanner_init.