### PR TITLE
Improve concurrency tests

### DIFF
--- a/test/concurrency.c
+++ b/test/concurrency.c
@@ -20,7 +20,7 @@ int main() {
   for (i = 0; i < THREAD_COUNT; i += 1) {
     ret = pthread_create(&threads[i], NULL, test_runner, NULL);
     if (ret) {
-      printf("ERROR creating pthread - pthread_create return code %d\n", ret);
+      perror("ERROR creating pthread");
       return 1;
     }
   }

--- a/test/concurrency.c
+++ b/test/concurrency.c
@@ -8,7 +8,7 @@
 
 #include "parse_tests.c"
 
-#define THREAD_COUNT 1000
+#define THREAD_COUNT 500
 
 void* test_runner(void*);
 


### PR DESCRIPTION
* Use `perror` to display the error in case the thread could not be created
* Lower the number of threads, 1000 made the test fail on my system with a lack of resources, which doesn't tell us anything about the actual code.