### PR TITLE
Ignore return value of asprintf without compiler warnings

### DIFF
--- a/src/pg_query_parse_plpgsql.c
+++ b/src/pg_query_parse_plpgsql.c
@@ -430,12 +430,11 @@ PgQueryPlpgsqlParseResult pg_query_parse_plpgsql(const char* input)
 		if (func_and_error.func != NULL) {
 			char *func_json;
 			char *new_out;
-			int ignored;
 
 			func_json = plpgsqlToJSON(func_and_error.func);
 			plpgsql_free_function_memory(func_and_error.func);
 
-			ignored = asprintf(&new_out, "%s%s,\n", result.plpgsql_funcs, func_json);
+			(void)asprintf(&new_out, "%s%s,\n", result.plpgsql_funcs, func_json);
 			free(result.plpgsql_funcs);
 			result.plpgsql_funcs = new_out;
 


### PR DESCRIPTION
```
src/pg_query_parse_plpgsql.c: In function ‘pg_query_parse_plpgsql’:
src/pg_query_parse_plpgsql.c:433:8: warning: variable ‘ignored’ set but not used [-Wunused-but-set-variable]
    int ignored;
        ^~~~~~~
```