### PR TITLE
update node community's library

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ pg_query wrappers in other languages:
 
 * Ruby: [pg_query](https://github.com/lfittl/pg_query)
 * Go: [pg_query_go](https://github.com/lfittl/pg_query_go)
-* Javascript (Node): [pg-query-parser](https://github.com/zhm/pg-query-parser)
+* Javascript (Node): [pgsql-parser](https://github.com/pyramation/pgsql-parser)
 * Javascript (Browser): [pg-query-emscripten](https://github.com/lfittl/pg-query-emscripten)
 * Python: [psqlparse](https://github.com/alculquicondor/psqlparse), [pglast](https://github.com/lelit/pglast)
 * OCaml: [pg_query-ocaml](https://github.com/roddyyaga/pg_query-ocaml)


### PR DESCRIPTION
Thank you for the amazing library! I appreciated getting coffee with you in SF a few years back... hope to catch up again!

I've updated to the link to the nodejs parser, as the the linked library hasn't been maintained. The author has been m.i.a. since January 2018 

Comparisons just in case you are curious

## Activity
summer of 2018 was last commit of real substance, although arguable 2017 and earlier was any real work. 

* `pgsql-parser` is 219 commits ahead and very actively developed.

![Screen Shot 2020-11-10 at 6 59 17 PM](https://user-images.githubusercontent.com/545047/98756168-4465a000-2387-11eb-8178-1a7322849875.png)


## Functionality

* `pgsql-parser` has implemented 95 AST nodes vs only 35 for the original library

![pgsql-parser](https://user-images.githubusercontent.com/545047/98756142-3879de00-2387-11eb-8df5-881fd9084c4b.png)


## Maintenence

* `pg-query-parser` is still on older version of PG (I think 9?) https://github.com/zhm/node-pg-query-native/blob/master/libpg_query/include/pg_query.h

* `pgsql-parser` has upgraded the underlying lib (https://github.com/pyramation/node-pg-query-native) to the PG 10 in this current `10-latest` branch (and I've even already experimented with 12/13 for when it's ready)

* unmaintained since Jan. 2018, issue opened in `pg-query-parser` "Still active?" https://github.com/zhm/pg-query-parser/issues/10

* numerous issues solved in `pgsql-parser`, but left open with no comms in `pg-query-parser`

https://github.com/zhm/pg-query-parser/issues/8
https://github.com/zhm/pg-query-parser/issues/17
https://github.com/zhm/pg-query-parser/issues/13






Still no response from owner.

numerous issues solved in new repo, but left open with no comms in zhm's:
https://github.com/zhm/pg-query-parser/issues/8
https://github.com/zhm/pg-query-parser/issues/17
https://github.com/zhm/pg-query-parser/issues/13