### PR TITLE
Table like clause issue

### DIFF
--- a/src/pg_query_deparse.c
+++ b/src/pg_query_deparse.c
@@ -4018,23 +4018,25 @@ static void deparseTableLikeClause(StringInfo str, TableLikeClause *table_like_c
 
 	if (table_like_clause->options == CREATE_TABLE_LIKE_ALL)
 		appendStringInfoString(str, "INCLUDING ALL ");
-	if (table_like_clause->options & CREATE_TABLE_LIKE_COMMENTS)
+        else
+        {
+	    if (table_like_clause->options & CREATE_TABLE_LIKE_COMMENTS)
 		appendStringInfoString(str, "INCLUDING COMMENTS ");
-	if (table_like_clause->options & CREATE_TABLE_LIKE_CONSTRAINTS)
+	    if (table_like_clause->options & CREATE_TABLE_LIKE_CONSTRAINTS)
 		appendStringInfoString(str, "INCLUDING CONSTRAINTS ");
-	if (table_like_clause->options & CREATE_TABLE_LIKE_DEFAULTS)
+	    if (table_like_clause->options & CREATE_TABLE_LIKE_DEFAULTS)
 		appendStringInfoString(str, "INCLUDING DEFAULTS ");
-	if (table_like_clause->options & CREATE_TABLE_LIKE_IDENTITY)
+	    if (table_like_clause->options & CREATE_TABLE_LIKE_IDENTITY)
 		appendStringInfoString(str, "INCLUDING IDENTITY ");
-	if (table_like_clause->options & CREATE_TABLE_LIKE_GENERATED)
+	    if (table_like_clause->options & CREATE_TABLE_LIKE_GENERATED)
 		appendStringInfoString(str, "INCLUDING GENERATED ");
-	if (table_like_clause->options & CREATE_TABLE_LIKE_INDEXES)
+	    if (table_like_clause->options & CREATE_TABLE_LIKE_INDEXES)
 		appendStringInfoString(str, "INCLUDING INDEXES ");
-	if (table_like_clause->options & CREATE_TABLE_LIKE_STATISTICS)
+	    if (table_like_clause->options & CREATE_TABLE_LIKE_STATISTICS)
 		appendStringInfoString(str, "INCLUDING STATISTICS ");
-	if (table_like_clause->options & CREATE_TABLE_LIKE_STORAGE)
+	    if (table_like_clause->options & CREATE_TABLE_LIKE_STORAGE)
 		appendStringInfoString(str, "INCLUDING STORAGE ");
-
+	}
 	removeTrailingSpace(str);
 }
 

--- a/src/pg_query_deparse.c
+++ b/src/pg_query_deparse.c
@@ -4018,24 +4018,24 @@ static void deparseTableLikeClause(StringInfo str, TableLikeClause *table_like_c
 
 	if (table_like_clause->options == CREATE_TABLE_LIKE_ALL)
 		appendStringInfoString(str, "INCLUDING ALL ");
-        else
-        {
-	    if (table_like_clause->options & CREATE_TABLE_LIKE_COMMENTS)
-		appendStringInfoString(str, "INCLUDING COMMENTS ");
-	    if (table_like_clause->options & CREATE_TABLE_LIKE_CONSTRAINTS)
-		appendStringInfoString(str, "INCLUDING CONSTRAINTS ");
-	    if (table_like_clause->options & CREATE_TABLE_LIKE_DEFAULTS)
-		appendStringInfoString(str, "INCLUDING DEFAULTS ");
-	    if (table_like_clause->options & CREATE_TABLE_LIKE_IDENTITY)
-		appendStringInfoString(str, "INCLUDING IDENTITY ");
-	    if (table_like_clause->options & CREATE_TABLE_LIKE_GENERATED)
-		appendStringInfoString(str, "INCLUDING GENERATED ");
-	    if (table_like_clause->options & CREATE_TABLE_LIKE_INDEXES)
-		appendStringInfoString(str, "INCLUDING INDEXES ");
-	    if (table_like_clause->options & CREATE_TABLE_LIKE_STATISTICS)
-		appendStringInfoString(str, "INCLUDING STATISTICS ");
-	    if (table_like_clause->options & CREATE_TABLE_LIKE_STORAGE)
-		appendStringInfoString(str, "INCLUDING STORAGE ");
+	else
+	{
+		if (table_like_clause->options & CREATE_TABLE_LIKE_COMMENTS)
+			appendStringInfoString(str, "INCLUDING COMMENTS ");
+		if (table_like_clause->options & CREATE_TABLE_LIKE_CONSTRAINTS)
+			appendStringInfoString(str, "INCLUDING CONSTRAINTS ");
+		if (table_like_clause->options & CREATE_TABLE_LIKE_DEFAULTS)
+			appendStringInfoString(str, "INCLUDING DEFAULTS ");
+		if (table_like_clause->options & CREATE_TABLE_LIKE_IDENTITY)
+			appendStringInfoString(str, "INCLUDING IDENTITY ");
+		if (table_like_clause->options & CREATE_TABLE_LIKE_GENERATED)
+			appendStringInfoString(str, "INCLUDING GENERATED ");
+		if (table_like_clause->options & CREATE_TABLE_LIKE_INDEXES)
+			appendStringInfoString(str, "INCLUDING INDEXES ");
+		if (table_like_clause->options & CREATE_TABLE_LIKE_STATISTICS)
+			appendStringInfoString(str, "INCLUDING STATISTICS ");
+		if (table_like_clause->options & CREATE_TABLE_LIKE_STORAGE)
+			appendStringInfoString(str, "INCLUDING STORAGE ");
 	}
 	removeTrailingSpace(str);
 }

--- a/test/deparse_tests.c
+++ b/test/deparse_tests.c
@@ -379,7 +379,8 @@ const char* tests[] = {
   "ALTER SYSTEM SET fsync TO OFF",
   "ALTER SYSTEM RESET fsync",
   "CREATE EXTENSION x",
-  "CREATE EXTENSION IF NOT EXISTS x CASCADE VERSION \"1.2\" SCHEMA a"
+  "CREATE EXTENSION IF NOT EXISTS x CASCADE VERSION \"1.2\" SCHEMA a",
+  "CREATE TABLE like_constraint_rename_cache (LIKE constraint_rename_cache INCLUDING ALL)"
 };
 
 size_t testsLength = __LINE__ - 4;


### PR DESCRIPTION
Hi Lukas,

while working on my `pglast` _deparser_ I noticed that the following statement
```sql
CREATE TABLE like_constraint_rename_cache   (LIKE constraint_rename_cache INCLUDING ALL)
```

gets deparsed by current `libpg_query` as
```sql
CREATE TABLE like_constraint_rename_cache (LIKE constraint_rename_cache INCLUDING ALL INCLUDING COMMENTS INCLUDING CONSTRAINTS INCLUDING DEFAULTS INCLUDING IDENTITY INCLUDING GENERATED INCLUDING INDEXES INCLUDING STATISTICS INCLUDING STORAGE)
```

It seems redundant, isn't it? If so, it this PR reasonable?

Unfortunately I could not run the tests locally, because a `make` stopped with
```
...
compiling src/postgres/src_port_strerror.c
compiling src/postgres/src_port_strnlen.c
compiling vendor/protobuf-c/protobuf-c.c
compiling vendor/xxhash/xxhash.c
Warning: protoc-gen-c not found, skipping protocol buffer regeneration
compiling protobuf/pg_query.pb-c.c
ar: Cannot convert existing thin library libpg_query.a to normal format
make: *** [Makefile:145: libpg_query.a] Errore 1
```

and I could not figure out what's wrong here... I'm on a Debian sid, if that matters.