### PR TITLE
Normalize: Fix handling of two subsequent DefElem elements

### DIFF
--- a/src/pg_query_normalize.c
+++ b/src/pg_query_normalize.c
@@ -318,8 +318,10 @@ static bool const_record_walker(Node *node, pgssConstLocations *jstate)
 		DefElem * defElem = (DefElem *) node;
 		if (defElem->arg != NULL && IsA(defElem->arg, String)) {
 			for (int i = defElem->location; i < jstate->query_len; i++) {
-				if (jstate->query[i] == '\'')
+				if (jstate->query[i] == '\'') {
 					RecordConstLocation(jstate, i);
+					break;
+			  }
 			}
 		}
 		return const_record_walker((Node *) ((DefElem *) node)->arg, jstate);

--- a/test/normalize_tests.c
+++ b/test/normalize_tests.c
@@ -7,6 +7,8 @@ const char* tests[] = {
   "ALTER ROLE postgres LOGIN SUPERUSER PASSWORD $1",
   "CREATE ROLE postgres ENCRYPTED PASSWORD 'xyz'",
   "CREATE ROLE postgres ENCRYPTED PASSWORD $1",
+  "ALTER ROLE foo WITH PASSWORD 'bar' VALID UNTIL 'infinity'",
+  "ALTER ROLE foo WITH PASSWORD $1 VALID UNTIL $2",
   // These below are as expected, though questionable if upstream shouldn't be
   // fixed as this could bloat pg_stat_statements
   "DECLARE cursor_b CURSOR FOR SELECT * FROM x WHERE id = 123",


### PR DESCRIPTION
We were incorrectly adding too many DefElem locations to the recorded
constant values, causing a crash when more than a single DefElem
is present in a utility statement.