### PR TITLE
Deparser: Fix crash in CopyStmt with HEADER or FREEZE inside WITH parens

### DIFF
--- a/src/pg_query_deparse.c
+++ b/src/pg_query_deparse.c
@@ -6678,9 +6678,11 @@ static void deparseCopyStmt(StringInfo str, CopyStmt *copy_stmt)
 				else
 					Assert(false);
 			}
-			else if (strcmp(def_elem->defname, "freeze") == 0 && intVal(def_elem->arg) == 1)
+			else if (strcmp(def_elem->defname, "freeze") == 0 && (def_elem->arg == NULL || intVal(def_elem->arg) == 1))
 			{
-				appendStringInfoString(str, "FREEZE 1");
+				appendStringInfoString(str, "FREEZE");
+				if (def_elem->arg != NULL && intVal(def_elem->arg) == 1)
+					appendStringInfoString(str, " 1");
 			}
 			else if (strcmp(def_elem->defname, "delimiter") == 0)
 			{
@@ -6692,9 +6694,11 @@ static void deparseCopyStmt(StringInfo str, CopyStmt *copy_stmt)
 				appendStringInfoString(str, "NULL ");
 				deparseStringLiteral(str, strVal(def_elem->arg));
 			}
-			else if (strcmp(def_elem->defname, "header") == 0 && intVal(def_elem->arg) == 1)
+			else if (strcmp(def_elem->defname, "header") == 0 && (def_elem->arg == NULL || intVal(def_elem->arg) == 1))
 			{
-				appendStringInfoString(str, "HEADER 1");
+				appendStringInfoString(str, "HEADER");
+				if (def_elem->arg != NULL && intVal(def_elem->arg) == 1)
+					appendStringInfoString(str, " 1");
 			}
 			else if (strcmp(def_elem->defname, "quote") == 0)
 			{

--- a/test/deparse_tests.c
+++ b/test/deparse_tests.c
@@ -380,7 +380,8 @@ const char* tests[] = {
   "ALTER SYSTEM RESET fsync",
   "CREATE EXTENSION x",
   "CREATE EXTENSION IF NOT EXISTS x CASCADE VERSION \"1.2\" SCHEMA a",
-  "CREATE TABLE like_constraint_rename_cache (LIKE constraint_rename_cache INCLUDING ALL)"
+  "CREATE TABLE like_constraint_rename_cache (LIKE constraint_rename_cache INCLUDING ALL)",
+  "COPY manual_export TO STDOUT WITH (FORMAT CSV, HEADER)"
 };
 
 size_t testsLength = __LINE__ - 4;


### PR DESCRIPTION
The parse tree does not contain an explicit argument in those cases,
but does when specified in the legacy mode without the wrapping WITH.

With this change we only output the "1" argument when the original tree
also had this, to ensure parse tree comparisons match. Note the intent
here is technically the same, which is to enable these options.