### PR TITLE
Add Rust pg_query option to wrapper list

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ pg_query wrappers in other languages:
 * Javascript (Browser): [pg-query-emscripten](https://github.com/pganalyze/pg-query-emscripten)
 * Python: [psqlparse](https://github.com/alculquicondor/psqlparse), [pglast](https://github.com/lelit/pglast)
 * OCaml: [pg_query-ocaml](https://github.com/roddyyaga/pg_query-ocaml)
-* Rust: [pg_query](https://github.com/paupino/pg_query)
+* Rust: [pg_query.rs](https://github.com/paupino/pg_query.rs)
 
 Products, tools and libraries built on pg_query:
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ pg_query wrappers in other languages:
 * Javascript (Browser): [pg-query-emscripten](https://github.com/pganalyze/pg-query-emscripten)
 * Python: [psqlparse](https://github.com/alculquicondor/psqlparse), [pglast](https://github.com/lelit/pglast)
 * OCaml: [pg_query-ocaml](https://github.com/roddyyaga/pg_query-ocaml)
+* Rust: [pg_query](https://github.com/paupino/pg_query)
 
 Products, tools and libraries built on pg_query:
 


### PR DESCRIPTION
This links to a basic wrapper for `libpg_query` transparently hiding many of the [FFI complexities](https://docs.rs/pg_query/0.1.1/pg_query/). So far this supports: `parse`, `normalize`, `fingerprint` and `parse_plpgsql`.

I see there is another Rust binding in the PR list too - the main differences between the two are that the other one exposes the raw FFI interface generated by `bindgen` whereas this one wraps it hiding the need for `unsafe` interactions.