### PR TITLE
Normalize: Don't touch "ORDER BY 1" expressions, keep original text

### DIFF
--- a/test/normalize_tests.c
+++ b/test/normalize_tests.c
@@ -9,8 +9,8 @@ const char* tests[] = {
   "CREATE ROLE postgres ENCRYPTED PASSWORD $1",
   "ALTER ROLE foo WITH PASSWORD 'bar' VALID UNTIL 'infinity'",
   "ALTER ROLE foo WITH PASSWORD $1 VALID UNTIL $2",
-  "SELECT a, SUM(b) FROM tbl WHERE c = 'foo' GROUP BY 1, 'bar'",
-  "SELECT a, SUM(b) FROM tbl WHERE c = $1 GROUP BY 1, $2",
+  "SELECT a, SUM(b) FROM tbl WHERE c = 'foo' GROUP BY 1, 'bar' ORDER BY 1, 'cafe'",
+  "SELECT a, SUM(b) FROM tbl WHERE c = $1 GROUP BY 1, $2 ORDER BY 1, $3",
   // These below are as expected, though questionable if upstream shouldn't be
   // fixed as this could bloat pg_stat_statements
   "DECLARE cursor_b CURSOR FOR SELECT * FROM x WHERE id = 123",


### PR DESCRIPTION
This avoids obscuring the semantic meaning of integers in the ORDER BY
clause, which is to reference a particular column in the target list.