### PR TITLE
Normalize: Don't modify constants in TypeName typmods/arrayBounds fields

### DIFF
--- a/src/pg_query_normalize.c
+++ b/src/pg_query_normalize.c
@@ -343,6 +343,9 @@ static bool const_record_walker(Node *node, pgssConstLocations *jstate)
 			return const_record_walker((Node *) ((AlterRoleStmt *) node)->options, jstate);
 		case T_DeclareCursorStmt:
 			return const_record_walker((Node *) ((DeclareCursorStmt *) node)->query, jstate);
+		case T_TypeName:
+			/* Don't normalize constants in typmods or arrayBounds */
+			return false;
 		case T_SelectStmt:
 			{
 				SelectStmt *stmt = (SelectStmt *) node;

--- a/test/normalize_tests.c
+++ b/test/normalize_tests.c
@@ -11,6 +11,8 @@ const char* tests[] = {
   "ALTER ROLE foo WITH PASSWORD $1 VALID UNTIL $2",
   "SELECT a, SUM(b) FROM tbl WHERE c = 'foo' GROUP BY 1, 'bar' ORDER BY 1, 'cafe'",
   "SELECT a, SUM(b) FROM tbl WHERE c = $1 GROUP BY 1, $2 ORDER BY 1, $3",
+  "SELECT CAST('abc' as varchar(50))",
+  "SELECT CAST($1 as varchar(50))",
   // These below are as expected, though questionable if upstream shouldn't be
   // fixed as this could bloat pg_stat_statements
   "DECLARE cursor_b CURSOR FOR SELECT * FROM x WHERE id = 123",


### PR DESCRIPTION
This matches how pg_stat_statement behaves, and avoids causing parsing
errors on the normalized statement.