### PR TITLE
Don't fail builds on systems that have strchrnul support (FreeBSD)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,10 @@ extract_source: $(PGDIR)
 	echo "#undef HAVE_BACKTRACE_SYMBOLS" >> ./src/postgres/include/pg_config.h
 	# Avoid dependency on cpuid.h (only supported on x86 systems)
 	echo "#undef HAVE__GET_CPUID" >> ./src/postgres/include/pg_config.h
+	# Ensure we don't fail on systems that have strchrnul support (FreeBSD)
+	echo "#ifdef __FreeBSD__" >> ./src/postgres/include/pg_config.h
+	echo "#define HAVE_STRCHRNUL" >> ./src/postgres/include/pg_config.h
+	echo "#endif" >> ./src/postgres/include/pg_config.h
 	# Copy version information so its easily accessible
 	sed -i "" '$(shell echo 's/\#define PG_MAJORVERSION .*/'`grep "\#define PG_MAJORVERSION " ./src/postgres/include/pg_config.h`'/')' pg_query.h
 	sed -i "" '$(shell echo 's/\#define PG_VERSION .*/'`grep "\#define PG_VERSION " ./src/postgres/include/pg_config.h`'/')' pg_query.h

--- a/src/postgres/include/pg_config.h
+++ b/src/postgres/include/pg_config.h
@@ -987,3 +987,6 @@
 #undef HAVE_EXECINFO_H
 #undef HAVE_BACKTRACE_SYMBOLS
 #undef HAVE__GET_CPUID
+#ifdef __FreeBSD__
+#define HAVE_STRCHRNUL
+#endif


### PR DESCRIPTION
This has to be added as an explicit check because we don't run through
./configure like the regular Postgres source, which would detect this
automatically.

Fixes the following build error on FreeBSD:

src_port_snprintf.c:374:1: error: static declaration of 'strchrnul'
follows non-static declaration
/usr/include/string.h:78:7: note: previous declaration is here