### PR TITLE
Normalize: Match GROUP BY against target list and re-use param refs

### DIFF
--- a/src/pg_query_fingerprint.c
+++ b/src/pg_query_fingerprint.c
@@ -291,6 +291,21 @@ _fingerprintNode(FingerprintContext *ctx, const void *obj, const void *parent, c
 	}
 }
 
+uint64_t pg_query_fingerprint_node(const void *node)
+{
+	FingerprintContext ctx;
+	uint64 result;
+
+	_fingerprintInitContext(&ctx, NULL, false);
+	_fingerprintNode(&ctx, node, NULL, NULL, 0);
+
+	result = XXH3_64bits_digest(ctx.xxh_state);
+
+	_fingerprintFreeContext(&ctx);
+
+	return result;
+}
+
 PgQueryFingerprintResult pg_query_fingerprint_with_opts(const char* input, bool printTokens)
 {
 	MemoryContext ctx = NULL;

--- a/src/pg_query_fingerprint.h
+++ b/src/pg_query_fingerprint.h
@@ -3,6 +3,8 @@
 
 #include <stdbool.h>
 
-PgQueryFingerprintResult pg_query_fingerprint_with_opts(const char* input, bool printTokens);
+extern PgQueryFingerprintResult pg_query_fingerprint_with_opts(const char* input, bool printTokens);
+
+extern uint64_t pg_query_fingerprint_node(const void * node);
 
 #endif

--- a/test/normalize_tests.c
+++ b/test/normalize_tests.c
@@ -11,6 +11,10 @@ const char* tests[] = {
   "ALTER ROLE foo WITH PASSWORD $1 VALID UNTIL $2",
   "SELECT a, SUM(b) FROM tbl WHERE c = 'foo' GROUP BY 1, 'bar' ORDER BY 1, 'cafe'",
   "SELECT a, SUM(b) FROM tbl WHERE c = $1 GROUP BY 1, $2 ORDER BY 1, $3",
+  "select date_trunc($1, created_at at time zone $2), count(*) from users group by date_trunc('day', created_at at time zone 'US/Pacific')",
+  "select date_trunc($1, created_at at time zone $2), count(*) from users group by date_trunc($1, created_at at time zone $2)",
+  "select count(1), date_trunc('day', created_at at time zone 'US/Pacific'), 'something', 'somethingelse' from users group by date_trunc('day', created_at at time zone 'US/Pacific'), date_trunc('day', created_at), 'foobar', 'abcdef'",
+  "select count($1), date_trunc($2, created_at at time zone $3), $4, $5 from users group by date_trunc($2, created_at at time zone $3), date_trunc($6, created_at), $4, $5",
   "SELECT CAST('abc' as varchar(50))",
   "SELECT CAST($1 as varchar(50))",
   // These below are as expected, though questionable if upstream shouldn't be


### PR DESCRIPTION
This avoids "columns ... must appear in the GROUP BY clause ..." type
errors when the normalize result is utilized as a parameterized query
with Postgres. We reuse the pg_query fingerprinting logic to determine
whether a target list element is identical with a GROUP BY element.

Note that query data coming from pg_stat_statements normalizes the target
list, but not the GROUP BY list.

Additionally, this overly optimizes for reusing param refs, specifically
when the target list contains elements that are similar, but not 100%
identical, we err on matching them (based on the pg_query fingerprint),
instead of requiring full equivalency. e.g. the target list may contain
a certain string constant and we would consider any other string constant
in the GROUP BY to be equivalent (since they have the same fingerprint).