### PR TITLE
Improve deparser error messages and top-level error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         sudo ldconfig
     - name: Install Valgrind
       if: matrix.valgrind == 'valgrind'
-      run: sudo apt install -y valgrind
+      run: sudo apt update && sudo apt install -y valgrind
     - name: Determine make flags
       id: make_flags
       run: |

--- a/src/pg_query_deparse.c
+++ b/src/pg_query_deparse.c
@@ -321,8 +321,7 @@ static void deparseExpr(StringInfo str, Node *node)
 			deparseGroupingFunc(str, castNode(GroupingFunc, node));
 			break;
 		default:
-			Assert(false);
-			elog(ERROR, "unpermitted node type in a_expr/b_expr: %d",
+			elog(ERROR, "deparse: unpermitted node type in a_expr/b_expr: %d",
 				 (int) nodeTag(node));
 			break;
 	}
@@ -372,8 +371,7 @@ static void deparseCExpr(StringInfo str, Node *node)
 			deparseGroupingFunc(str, castNode(GroupingFunc, node));
 			break;
 		default:
-			Assert(false);
-			elog(ERROR, "unpermitted node type in c_expr: %d",
+			elog(ERROR, "deparse: unpermitted node type in c_expr: %d",
 				 (int) nodeTag(node));
 			break;
 	}
@@ -1416,7 +1414,7 @@ static void deparseTargetList(StringInfo str, List *l)
 		ResTarget *res_target = castNode(ResTarget, lfirst(lc));
 
 		if (res_target->val == NULL)
-			elog(ERROR, "deparse error in deparseTargetList: ResTarget without val");
+			elog(ERROR, "deparse: error in deparseTargetList: ResTarget without val");
 		else if (IsA(res_target->val, ColumnRef))
 			deparseColumnRef(str, castNode(ColumnRef, res_target->val));
 		else
@@ -9427,7 +9425,7 @@ static void deparseValue(StringInfo str, Value *value, DeparseNodeContext contex
 			appendStringInfoString(str, "NULL");
 			break;
 		default:
-			elog(ERROR, "unrecognized value node type: %d",
+			elog(ERROR, "deparse: unrecognized value node type: %d",
 				 (int) nodeTag(value));
 			break;
 	}
@@ -9900,8 +9898,7 @@ static void deparseStmt(StringInfo str, Node *node)
 			deparseCreateRangeStmt(str, castNode(CreateRangeStmt, node));
 			break;
 		default:
-			// No other node types are supported at the top-level
-			Assert(false);
+			elog(ERROR, "deparse: unsupported top-level node type: %u", nodeTag(node));
 	}
 }
 

--- a/test/deparse_tests.c
+++ b/test/deparse_tests.c
@@ -104,6 +104,7 @@ const char* tests[] = {
   "INSERT INTO x (y, z) VALUES (1, 'abc') ON CONFLICT (y) DO NOTHING RETURNING y",
   "INSERT INTO distributors (did, dname) VALUES (10, 'Conrad International') ON CONFLICT (did) WHERE is_active DO NOTHING",
   "INSERT INTO distributors (did, dname) VALUES (9, 'Antwerp Design') ON CONFLICT ON CONSTRAINT distributors_pkey DO NOTHING",
+  "INSERT INTO foo (a, b, c, d) VALUES ($1) ON CONFLICT (id) DO UPDATE SET (a, b, c, d) = (excluded.a, excluded.b, excluded.c, CASE WHEN foo.d = excluded.d THEN excluded.d END)",
   "INSERT INTO employees SELECT * FROM people WHERE 1 = 1 GROUP BY name HAVING count(name) > 1 ORDER BY name DESC LIMIT 10 OFFSET 15 FOR UPDATE",
   "INSERT INTO films VALUES ('T_601', 'Yojimbo', 106, DEFAULT, 'Drama', DEFAULT)",
   "SELECT * FROM people FOR UPDATE OF name, email",


### PR DESCRIPTION
```
Deparser: Prefix errors with "deparse", and remove some asserts

Most importantly, this replaces the top-level assert when passing in
a bad node with an error message instead. Previously this would have
silently returned an empty query string instead in non-assert enabled
builds.
```

```
Deparser: Add additional test case that includes a MultiAssignRef node

This is mostly added for improved coverage, but not actually addressing
a particular bug case, as it was already working correctly in the deparser.
```

```
GH actions: Fix valgrind install
```