### PR TITLE
Don't bail on #? operator name

### DIFF
--- a/patches/02_parser_support_question_mark_as_param_ref.patch
+++ b/patches/02_parser_support_question_mark_as_param_ref.patch
@@ -315,7 +315,7 @@ index b1ea0cb538..9ba31f418c 100644
 +						nchars = 1;
 +
 +					if (yytext[0] != '?' && strchr(yytext, '?') &&
-+					  strcmp(yytext, "@?") != 0)
++					  strcmp(yytext, "#?") != 0 && strcmp(yytext, "@?") != 0)
 +						/* Lex up to just before the ? character */
 +						nchars = strchr(yytext, '?') - yytext;
 +

--- a/src/postgres/src_backend_parser_scan.c
+++ b/src/postgres/src_backend_parser_scan.c
@@ -5664,7 +5664,7 @@ YY_RULE_SETUP
 						nchars = 1;
 
 					if (yytext[0] != '?' && strchr(yytext, '?') &&
-					  strcmp(yytext, "@?") != 0)
+					  strcmp(yytext, "#?") != 0 && strcmp(yytext, "@?") != 0)
 						/* Lex up to just before the ? character */
 						nchars = strchr(yytext, '?') - yytext;
 


### PR DESCRIPTION
The following statement will produce an error with pg_query_parse
while being accepted by PG13.

CREATE OPERATOR #? (LEFTARG=bool,RIGHTARG=bool,FUNCTION=boolge);

https://github.com/pganalyze/libpg_query/issues/132