### PR TITLE
Add operators used by ltree extension

### DIFF
--- a/patches/02_parser_support_question_mark_as_param_ref.patch
+++ b/patches/02_parser_support_question_mark_as_param_ref.patch
@@ -309,13 +309,16 @@ index b1ea0cb538..9ba31f418c 100644
 +					 * spacing between ? as a substition character and a simple operator (e.g. "?=?")
 +					 */
 +					if (yytext[0] == '?' &&
++					  strcmp(yytext, "?<@") != 0 && strcmp(yytext, "?@>") != 0 &&
++					  strcmp(yytext, "?~") != 0 && strcmp(yytext, "?@") != 0 &&
 +					  strcmp(yytext, "?|") != 0 && strcmp(yytext, "?&") != 0 &&
 +					  strcmp(yytext, "?#") != 0 && strcmp(yytext, "?-") != 0 &&
 +					  strcmp(yytext, "?-|") != 0 && strcmp(yytext, "?||") != 0)
 +						nchars = 1;
 +
 +					if (yytext[0] != '?' && strchr(yytext, '?') &&
-+					  strcmp(yytext, "#?") != 0 && strcmp(yytext, "@?") != 0)
++					  strcmp(yytext, "^?") != 0 && strcmp(yytext, "#?") != 0 &&
++					  strcmp(yytext, "@?") != 0)
 +						/* Lex up to just before the ? character */
 +						nchars = strchr(yytext, '?') - yytext;
 +

--- a/src/postgres/src_backend_parser_scan.c
+++ b/src/postgres/src_backend_parser_scan.c
@@ -5658,13 +5658,16 @@ YY_RULE_SETUP
 					 * spacing between ? as a substition character and a simple operator (e.g. "?=?")
 					 */
 					if (yytext[0] == '?' &&
+					  strcmp(yytext, "?<@") != 0 && strcmp(yytext, "?@>") != 0 &&
+					  strcmp(yytext, "?~") != 0 && strcmp(yytext, "?@") != 0 &&
 					  strcmp(yytext, "?|") != 0 && strcmp(yytext, "?&") != 0 &&
 					  strcmp(yytext, "?#") != 0 && strcmp(yytext, "?-") != 0 &&
 					  strcmp(yytext, "?-|") != 0 && strcmp(yytext, "?||") != 0)
 						nchars = 1;
 
 					if (yytext[0] != '?' && strchr(yytext, '?') &&
-					  strcmp(yytext, "#?") != 0 && strcmp(yytext, "@?") != 0)
+					  strcmp(yytext, "^?") != 0 && strcmp(yytext, "#?") != 0 &&
+					  strcmp(yytext, "@?") != 0)
 						/* Lex up to just before the ? character */
 						nchars = strchr(yytext, '?') - yytext;
 


### PR DESCRIPTION
This makes libpg_query no longer error on the following operators
used by the ltree extension: ?<@ ?@> ?~ ?@ ^?