### PR TITLE
Fix memory leak in pg_query_fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ pg_query wrappers in other languages:
 * Javascript (Browser): [pg-query-emscripten](https://github.com/pganalyze/pg-query-emscripten)
 * Python: [psqlparse](https://github.com/alculquicondor/psqlparse), [pglast](https://github.com/lelit/pglast)
 * OCaml: [pg_query-ocaml](https://github.com/roddyyaga/pg_query-ocaml)
-* Rust: [pg_query.rs](https://github.com/paupino/pg_query.rs)
+* Rust: [pg_query.rs](https://github.com/pganalyze/pg_query.rs)
 
 Products, tools and libraries built on pg_query:
 

--- a/src/pg_query_fingerprint.c
+++ b/src/pg_query_fingerprint.c
@@ -374,6 +374,7 @@ void pg_query_free_fingerprint_result(PgQueryFingerprintResult result)
 	if (result.error) {
 		free(result.error->message);
 		free(result.error->filename);
+		free(result.error->funcname);
 		free(result.error);
 	}
 

--- a/test/fingerprint.c
+++ b/test/fingerprint.c
@@ -37,6 +37,14 @@ int main()
 		pg_query_free_fingerprint_result(result);
 	}
 
+	// Ensures that there isn't a memory leak in the error case
+	PgQueryFingerprintResult result = pg_query_fingerprint("SELECT !");
+	if (strcmp(result.error->message, "syntax error at end of input") != 0) {
+		printf("\nERROR mismatch: %s\n", result.error->message);
+		return EXIT_FAILURE;
+	}
+	pg_query_free_fingerprint_result(result);
+
 	printf("\n");
 
 	pg_query_exit();


### PR DESCRIPTION
Before adding the missing `free`, the new test fails:

<img width="980" alt="Screen Shot 2022-06-03 at 1 37 43 PM" src="https://user-images.githubusercontent.com/688886/171931597-f05d39e4-057a-4e84-aae9-3eb3327c739c.png">