### PR TITLE
Fix test count in examples/scan.c

### DIFF
--- a/examples/scan.c
+++ b/examples/scan.c
@@ -4,7 +4,7 @@
 
 #include "protobuf/pg_query.pb-c.h"
 
-size_t testCount = 12;
+size_t testCount = 13;
 const char* tests[] = {
   "SELECT 1",
   "SELECT \\s 1",


### PR DESCRIPTION
commit 32699d10fee9764e2094503d24cbd0984cd2fab8 added a new test without increasing the test count variable.