### PR TITLE
Added SWIG Java changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ jobs:
         os: [ubuntu-20.04]
         compiler: [clang, gcc]
         protobuf_lib: [protobuf-c, protobuf-cpp]
-        valgrind: [valgrind,no-valgrind]
+        valgrind: [valgrind, no-valgrind]
+        swig: [java, none]      # NS: Add swig matrix.
+        exclude:                # NS: Excluding combinations (for now) that break the build.
+          - protobuf_lib: protobuf-cpp
+            swig: java
     steps:
     - name: Check out code
       uses: actions/checkout@v2
@@ -39,6 +43,9 @@ jobs:
     - name: Install Valgrind
       if: matrix.valgrind == 'valgrind'
       run: sudo apt update && sudo apt install -y valgrind
+    - name: Install SWIG        # NS: Install swig if needed.
+      if: matrix.swig != 'none'
+      run: sudo apt update && sudo apt install -y swig
     - name: Determine make flags
       id: make_flags
       run: |
@@ -67,7 +74,23 @@ jobs:
         PROTOBUF_LIB: ${{ matrix.protobuf_lib }}
         COMPILER: ${{ matrix.compiler }}
         VALGRIND: ${{ matrix.valgrind }}
+    - name: Generate SWIG-Java Bindings # NS: Generate Java and C code.
+      if: matrix.swig == 'java'
+      run: |
+        mkdir -p bindings/java/src/main/java/pg_query
+        swig -java -package pg_query -outdir bindings/java/src/main/java/pg_query -o src/pg_query_wrap_java.c pg_query.i
     - name: Build and run tests
       run: make $FLAGS
       env:
         FLAGS: ${{ format('{0} {1} {2}', steps.make_flags.outputs.proto_flags, steps.make_flags.outputs.compiler_flags, steps.make_flags.outputs.debug_flags) }}
+        CFLAGS: "-I${JAVA_HOME_11_X64}/include -I${JAVA_HOME_11_X64}/include/linux" # NS: Set CFLAGS env var to pick up jni.h headers.
+    - name: Build Shared Library # NS: Now build the shared library so we can use it in bindings (like Java JNI).
+      if: matrix.swig != 'none'
+      run: make build_shared $FLAGS
+      env:
+        FLAGS: ${{ format('{0} {1} {2}', steps.make_flags.outputs.proto_flags, steps.make_flags.outputs.compiler_flags, steps.make_flags.outputs.debug_flags) }}
+    - name: Compile SWIG-Java Bindings # NS: Now build the Java package using the libpg_query.so shared library.
+      if: matrix.swig == 'java'
+      run: |
+        cp libpg_query.so bindings/java
+        mvn -f bindings/java/pom.xml package

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ postgres.tar.bz2
 
 *.o
 *.a
+*.so
 
 examples/*
 !examples/*.c
@@ -17,3 +18,8 @@ test/*.dSYM
 
 tmp/*
 !tmp/.gitkeep
+
+bindings/java/src
+bindings/java/target
+
+src/pg_query_wrap_java.c

--- a/README.md
+++ b/README.md
@@ -280,3 +280,67 @@ Portions Copyright (c) 1994, The Regents of the University of California
 
 All other parts are licensed under the 3-clause BSD license, see LICENSE file for details.<br>
 Copyright (c) 2017, Lukas Fittl <lukas@fittl.com>
+
+## SWIG-Java Bindings ##
+
+David A. Ventimiglia (DAV) at NeptuneStation.org added SWIG-Java bindings.
+
+### What ###
+
+There are projects that use libpg_query as a base library for Ruby,
+Go, Node, Python, and Python 3.  However, there may not be a project
+that uses libpg_query as a base library for Java.  Moreover, those
+other projects may each diverge from a standard approach.  Therefore,
+this project attempts to use libpg_query as a base library for Java
+and it does so using SWIG.
+
+### Why ###
+
+There are two primary objectives for this project.
+
+1. Add Java bindings for libpg_query.
+2. Create opportunities for standardization by using SWIG.
+
+There also are two secondary objectives for this project.
+
+1. Explore adding different language bindings directly into the
+   libpg_query project and library rather than as external projects
+   and libraries.
+2. Do so with as light a "footprint" as possible.
+
+### How ###
+
+1. Add a top-level `bindings` directory to contain language-specific
+   material for different language bindings (e.g. Java, Python, etc.).
+2. Add a next-level `bindings/java` directory to contain
+   language-specific material for a Java language binding.  This is a
+   Maven project directory.
+3. Add a `bindings/java/pom.xml` file to configure a Maven project.
+4. Within `bindings/java/pom.xml` configure the
+   `maven-surefire-plugin` (which runs tests) to set a system property
+   so that Java can load the `libpg_query.so` shared library, since
+   the Java code uses JNI (via SWIG) to access the library.
+5. Add a `bindings/java/src/main/java` standard Maven sub-directory
+   tree to hold the language-specific output from SWIG.
+6. Add a `bindings/java/src/test/java` standard Maven sub-directory
+   tree to hold the language-specific (Java) source code for tests.
+7. Modified `.github/workflows/ci.yml`:
+   1. Added GitHub Action matrix dimension for `swig` (currently:
+      `java`, `none`).
+   2. Added matrix exclusions for combinations that currently break
+      the build.
+   3. Added a step to install SWIG when needed.
+   4. Added a step *before* compiling the C code to invoke SWIG to
+      generate the C (and Java) wrappers, as the C wrappers are needed
+      before compiling the library.
+   5. Modified the step to compile the C code using `make` by setting
+      the `CFLAGS` environment variable to pick up the needed Java JNI
+      headers `jni.h`.
+   6. Added a step *after* compiling the C code to call `make
+      build_shared` to build the `libpg_query.so` shared object
+      library. 
+   7. Added a final step to run a Maven build in the `bindings/java`
+      Maven project directory, to compile and package the Java portion
+      of the code into a JAR file.  This also runs Java tests that
+      *use* the `libpg_query.so` shared object library created
+      previously. 

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>pg_query</groupId>
+  <artifactId>PgQuery</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>PgQuery</name>
+  <url>https://github.com/pganalyze/libpg_query</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M7</version>
+				<configuration>
+					<argLine>-Djava.library.path=${project.basedir}</argLine> <!--NS: Tell java (junit) where to find the libpg_query shared library.-->
+				</configuration>
+			</plugin>
+		</plugins>
+
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+      <plugins>
+        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.7.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/bindings/java/src/test/java/pg_query/AppTest.java
+++ b/bindings/java/src/test/java/pg_query/AppTest.java
@@ -1,0 +1,23 @@
+package pg_query;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest {
+		static {
+				System.loadLibrary("pg_query");
+		}
+
+		/**
+		 * Rigorous Test :-)
+		 */
+		@Test
+		public void shouldAnswerWithTrue () {
+				System.out.println(PgQuery.pg_query_parse("select 1"));
+				assertTrue( true );
+		}
+}

--- a/pg_query.i
+++ b/pg_query.i
@@ -1,0 +1,5 @@
+%module PgQuery									/* NS: This is lso the main Java class name. */
+%{
+#include "pg_query.h"						/* NS: Include the pg_query.h header in the generate C/C++ files. */
+%}
+%include "pg_query.h"						/* NS: Tell SWIG to analyze the pg_query.h header. */


### PR DESCRIPTION
Hello @lfittl !

I'm submitting this PR but I don't expect you to merge it.  Consider it more of a proposal.  Would you ever consider using something like [SWIG](https://www.swig.org/) to put language bindings directly into this project and library?  The reason I ask is that like there're bindings for Go, Ruby, etc., I wanted there to be bindings in Java.  Not seeing them, I decided to create them.  Being a lazy person, I picked an easy path, which was to use SWIG.  But, then I saw that it took little effort and I wondered if this might be a nice approach for laying down a common baseline foundation for Go, Ruby, etc.  as well.  Anyway, it's just a POC.  Were it to be taken forward, some things to do would be:

1. fix the broken build for protobuf-cpp + swig
2. add lots more test cases in Java
3. tighten up the Java/Maven build part
4. adopt [one-jar](https://one-jar.sourceforge.net/) approach
5. since Java is supposed to be cross-platform, cross-compile on many other architectures (Windows DLL, e.g.)

Anyway, if you get a chance take a look and please let me know what you think.  Thanks so much.
Regards,
David