### PR TITLE
GH actions: add CIFuzz integration

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,26 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'libpg_query'
+        dry-run: false
+        language: c
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'libpg_query'
+        fuzz-seconds: 300
+        dry-run: false
+        language: c
+    - name: Upload Crash
+      uses: actions/upload-artifact@v3
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
Add [CIFuzz](https://google.github.io/oss-fuzz/getting-started/continuous-integration/) workflow action to have fuzzers build and run on each PR.

This is a service offered by OSS-Fuzz where libpg_query already runs. CIFuzz can help detect catch regressions and fuzzing build issues early, and has a variety of features (see the URL above). In the current PR the fuzzers gets build on a pull request and will run for 300 seconds.

Signed-off-by: David Korczynski <david@adalogics.com>