### PR TITLE
pg_config.h: NetBSD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,8 +146,8 @@ $(PGDIR):
 	# Avoid CRC extension usage to ensure we are not architecture-dependent
 	echo "#undef USE_ARMV8_CRC32C" >> $(PGDIR)/src/include/pg_config.h
 	echo "#undef USE_SSE42_CRC32C_WITH_RUNTIME_CHECK" >> $(PGDIR)/src/include/pg_config.h
-	# Ensure we don't fail on systems that have strchrnul support (FreeBSD)
-	echo "#ifdef __FreeBSD__" >> $(PGDIR)/src/include/pg_config.h
+	# Ensure we don't fail on systems that have strchrnul support (FreeBSD and NetBSD)
+	echo "#if defined(__FreeBSD__) || defined(__NetBSD__)" >> $(PGDIR)/src/include/pg_config.h
 	echo "#define HAVE_STRCHRNUL" >> $(PGDIR)/src/include/pg_config.h
 	echo "#endif" >> $(PGDIR)/src/include/pg_config.h
 

--- a/src/postgres/include/pg_config.h
+++ b/src/postgres/include/pg_config.h
@@ -1032,6 +1032,6 @@
 #undef HAVE__GET_CPUID
 #undef USE_ARMV8_CRC32C
 #undef USE_SSE42_CRC32C_WITH_RUNTIME_CHECK
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__NetBSD__)
 #define HAVE_STRCHRNUL
 #endif


### PR DESCRIPTION
This is the same as pganalyze/pg_query_go#72 except one level higher.

NetBSD has `strchrnul` too but with a slightly different prototype. Without this change, there is a compiler error for a conflicting declaration.