### PR TITLE
License file's copyright is stuck in 2015

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Lukas Fittl <lukas@fittl.com>
+Copyright (c) 2015-2023, Lukas Fittl <lukas@fittl.com>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Update it to reflect libpog_query's active status.

P.S. I am incorporating portions of the library into another open source project (more on that later) and I noticed that the copyright in the license hasn't been updated in a while.