### PR TITLE
Update copyright notice to reflect current years + pganalyze as author

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2015, Lukas Fittl <lukas@fittl.com>
+Copyright (c) 2016-2023, Duboce Labs, Inc. (pganalyze) <team@pganalyze.com>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -281,4 +281,5 @@ Portions Copyright (c) 1996-2023, The PostgreSQL Global Development Group<br>
 Portions Copyright (c) 1994, The Regents of the University of California
 
 All other parts are licensed under the 3-clause BSD license, see LICENSE file for details.<br>
-Copyright (c) 2017, Lukas Fittl <lukas@fittl.com>
+Copyright (c) 2015, Lukas Fittl <lukas@fittl.com>
+Copyright (c) 2016-2023, Duboce Labs, Inc. (pganalyze) <team@pganalyze.com>

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Please feel free to [open a PR](https://github.com/pganalyze/libpg_query/pull/ne
 ## License
 
 PostgreSQL server source code, used under the [PostgreSQL license](https://www.postgresql.org/about/licence/).<br>
-Portions Copyright (c) 1996-2017, The PostgreSQL Global Development Group<br>
+Portions Copyright (c) 1996-2023, The PostgreSQL Global Development Group<br>
 Portions Copyright (c) 1994, The Regents of the University of California
 
 All other parts are licensed under the 3-clause BSD license, see LICENSE file for details.<br>


### PR DESCRIPTION
Since this library is now collectively maintained by pganalyze as a company, not just by myself (Lukas), it seems logical to expand the LICENSE file to cover this copyright explicitly.