### PR TITLE
Remove limits.h from pg_query_deparse.c

### DIFF
--- a/src/pg_query_deparse.c
+++ b/src/pg_query_deparse.c
@@ -11,7 +11,6 @@
 #include "common/keywords.h"
 #include "common/kwlookup.h"
 #include "lib/stringinfo.h"
-#include "limits.h"
 #include "nodes/nodes.h"
 #include "nodes/parsenodes.h"
 #include "nodes/pg_list.h"


### PR DESCRIPTION
It is (no longer?) needed for the file to be compiled

Closes #176