### PR TITLE
Deparser: Ensure index names are quoted as identifiers

### DIFF
--- a/src/pg_query_deparse.c
+++ b/src/pg_query_deparse.c
@@ -7938,7 +7938,7 @@ static void deparseIndexStmt(StringInfo str, IndexStmt *index_stmt)
 
 	if (index_stmt->idxname != NULL)
 	{
-		appendStringInfoString(str, index_stmt->idxname);
+		appendStringInfoString(str, quote_identifier(index_stmt->idxname));
 		appendStringInfoChar(str, ' ');
 	}
 

--- a/test/deparse_tests.c
+++ b/test/deparse_tests.c
@@ -387,6 +387,7 @@ const char* tests[] = {
   "ALTER TABLE ALL IN TABLESPACE foo OWNED BY bar, quux SET TABLESPACE fred NOWAIT",
   "MERGE INTO measurement m USING new_measurement nm ON m.city_id = nm.city_id AND m.logdate = nm.logdate WHEN MATCHED AND nm.peaktemp IS NULL THEN DELETE WHEN MATCHED THEN UPDATE SET peaktemp = GREATEST(m.peaktemp, nm.peaktemp), unitsales = m.unitsales + COALESCE(nm.unitsales, 0) WHEN NOT MATCHED THEN INSERT (city_id, logdate, peaktemp, unitsales) VALUES (city_id, logdate, peaktemp, unitsales)",
   "COPY vistest FROM STDIN FREEZE CSV",
+  "CREATE INDEX \"foo.index\" ON foo USING btree (bar)",
 };
 
 size_t testsLength = __LINE__ - 4;


### PR DESCRIPTION
Fixes https://github.com/pganalyze/pg_query_go/issues/77