### PR TITLE
Create table unique index parameters problem fixed

### DIFF
--- a/src/pg_query_deparse.c
+++ b/src/pg_query_deparse.c
@@ -4695,7 +4695,7 @@ static void deparseConstraint(StringInfo str, Constraint *constraint)
 		deparseColumnList(str, constraint->keys);
 		appendStringInfoString(str, ") ");
 	}
-		
+
 	if (list_length(constraint->fk_attrs) > 0)
 	{
 		appendStringInfoChar(str, '(');

--- a/src/pg_query_deparse.c
+++ b/src/pg_query_deparse.c
@@ -9440,7 +9440,7 @@ static void deparseVariableShowStmt(StringInfo str, VariableShowStmt *variable_s
 	else if (strcmp(variable_show_stmt->name, "session_authorization") == 0)
 		appendStringInfoString(str, "SESSION AUTHORIZATION");
 	else if (strcmp(variable_show_stmt->name, "all") == 0)
-		appendStringInfoString(str, "SESSION ALL");
+		appendStringInfoString(str, "ALL");
 	else
 		appendStringInfoString(str, quote_identifier(variable_show_stmt->name));
 }

--- a/src/pg_query_deparse.c
+++ b/src/pg_query_deparse.c
@@ -4695,9 +4695,7 @@ static void deparseConstraint(StringInfo str, Constraint *constraint)
 		deparseColumnList(str, constraint->keys);
 		appendStringInfoString(str, ") ");
 	}
-
-	deparseOptWith(str, constraint->options);
-
+		
 	if (list_length(constraint->fk_attrs) > 0)
 	{
 		appendStringInfoChar(str, '(');
@@ -4798,6 +4796,17 @@ static void deparseConstraint(StringInfo str, Constraint *constraint)
 		appendStringInfoString(str, "INCLUDE (");
 		deparseColumnList(str, constraint->including);
 		appendStringInfoString(str, ") ");
+	}
+
+	switch (constraint->contype)
+	{
+		case CONSTR_PRIMARY:
+		case CONSTR_UNIQUE:
+		case CONSTR_EXCLUSION:
+			deparseOptWith(str, constraint->options);
+			break;
+		default:
+			break;
 	}
 
 	if (constraint->indexname != NULL)

--- a/src/pg_query_deparse.c
+++ b/src/pg_query_deparse.c
@@ -4696,6 +4696,8 @@ static void deparseConstraint(StringInfo str, Constraint *constraint)
 		appendStringInfoString(str, ") ");
 	}
 
+	deparseOptWith(str, constraint->options);
+
 	if (list_length(constraint->fk_attrs) > 0)
 	{
 		appendStringInfoChar(str, '(');

--- a/test/deparse_tests.c
+++ b/test/deparse_tests.c
@@ -391,6 +391,7 @@ const char* tests[] = {
   "COPY vistest FROM STDIN FREEZE CSV",
   "CREATE INDEX \"foo.index\" ON foo USING btree (bar)",
   "CREATE TABLE distributors (did int, name varchar(40), UNIQUE (name) WITH (fillfactor=70)) WITH (fillfactor=70)",
+  "SHOW ALL",
 };
 
 size_t testsLength = __LINE__ - 4;

--- a/test/deparse_tests.c
+++ b/test/deparse_tests.c
@@ -390,6 +390,7 @@ const char* tests[] = {
   "MERGE INTO measurement m USING new_measurement nm ON m.city_id = nm.city_id AND m.logdate = nm.logdate WHEN MATCHED AND nm.peaktemp IS NULL THEN DELETE WHEN MATCHED THEN UPDATE SET peaktemp = GREATEST(m.peaktemp, nm.peaktemp), unitsales = m.unitsales + COALESCE(nm.unitsales, 0) WHEN NOT MATCHED THEN INSERT (city_id, logdate, peaktemp, unitsales) VALUES (city_id, logdate, peaktemp, unitsales)",
   "COPY vistest FROM STDIN FREEZE CSV",
   "CREATE INDEX \"foo.index\" ON foo USING btree (bar)",
+  "CREATE TABLE distributors (did int, name varchar(40), UNIQUE (name) WITH (fillfactor=70)) WITH (fillfactor=70)",
 };
 
 size_t testsLength = __LINE__ - 4;


### PR DESCRIPTION
```
     SQL: CREATE TABLE distributors (         
              did     int,
              name    varchar(40),
              UNIQUE (name) WITH (fillfactor=70)
            )
            WITH (fillfactor=70);

       expected: "CREATE TABLE distributors (did int, name varchar(40), UNIQUE (name) WITH (fillfactor=70)) WITH (fillfactor=70)"
            got: "CREATE TABLE distributors (did int, name varchar(40), UNIQUE (name)) WITH (fillfactor=70)"
```
pg_query PR: https://github.com/pganalyze/pg_query/pull/287