### PR TITLE
Deparser: Correctly quote identifier in ALTER TABLE ... ADD CONSTRAINT [x]

### DIFF
--- a/src/postgres_deparse.c
+++ b/src/postgres_deparse.c
@@ -4593,7 +4593,7 @@ static void deparseConstraint(StringInfo str, Constraint *constraint)
 	if (constraint->conname != NULL)
 	{
 		appendStringInfoString(str, "CONSTRAINT ");
-		appendStringInfoString(str, constraint->conname);
+		appendStringInfoString(str, quote_identifier(constraint->conname));
 		appendStringInfoChar(str, ' ');
 	}
 

--- a/test/deparse_tests.c
+++ b/test/deparse_tests.c
@@ -392,6 +392,7 @@ const char* tests[] = {
   "CREATE INDEX \"foo.index\" ON foo USING btree (bar)",
   "CREATE TABLE distributors (did int, name varchar(40), UNIQUE (name) WITH (fillfactor=70)) WITH (fillfactor=70)",
   "SHOW ALL",
+  "ALTER TABLE ONLY public.\"Test 123\" ADD CONSTRAINT \"Test 123_pkey\" PRIMARY KEY (c1)",
 };
 
 size_t testsLength = __LINE__ - 4;


### PR DESCRIPTION
As reported in https://github.com/pganalyze/pg_query_go/issues/88