### PR TITLE
Deparser: Add support for COALESCE and other expressions in LIMIT clause

### DIFF
--- a/test/deparse_tests.c
+++ b/test/deparse_tests.c
@@ -397,6 +397,7 @@ const char* tests[] = {
   "CREATE PROCEDURE do_nothing() LANGUAGE sql BEGIN ATOMIC END",
   "CREATE PROCEDURE returns_one() LANGUAGE sql BEGIN ATOMIC RETURN 1; END",
   "CREATE PROCEDURE updates_and_returns_one() LANGUAGE sql BEGIN ATOMIC UPDATE tbl SET a = 1; RETURN 1; END",
+  "SELECT 1 FROM tbl LIMIT COALESCE($1, $2)",
 };
 
 size_t testsLength = __LINE__ - 4;


### PR DESCRIPTION
We've previously supported "c_expr" being used in a LIMIT clause, but its actually more correct to treat this as "a_expr", which is a broader set of functions, including COALESCE.

Note that the previous handling (for "c_expr") is still correct for FETCH FIRST (expr) ROWS WITH TIES, see the "select_fetch_first_value" in the Postgres grammar.

In passing fix two new warnings in the deparser caused by a recent code addition.