### PR TITLE
Makefile: Use -Wall for compiling tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ override CFLAGS += -g -I. -I./vendor -I./src/postgres/include -Wall -Wno-unused-
 
 override PG_CONFIGURE_FLAGS += -q --without-readline --without-zlib
 
-override TEST_CFLAGS += -I. -I./vendor -g
+override TEST_CFLAGS += -g -I. -I./vendor -Wall
 override TEST_LDFLAGS += -pthread
 
 CFLAGS_OPT_LEVEL = -O3

--- a/test/concurrency.c
+++ b/test/concurrency.c
@@ -1,10 +1,11 @@
 #include <pg_query.h>
 
+#include <assert.h>
+#include <pthread.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
-#include <pthread.h>
 
 #include "parse_tests.c"
 
@@ -38,7 +39,8 @@ int main() {
   return 0;
 }
 
-void* test_runner(void* ptr) {
+void* test_runner(void* unused_pthread_arg) {
+  assert(unused_pthread_arg == NULL);
   size_t i;
 
   for (i = 0; i < testsLength; i += 2) {


### PR DESCRIPTION
CFLAGS uses -Wall along with some -Wno-* options. However, tests are compiled using TEST_CFLAGS, so they did not use these options. Compile tests with -Wall. This also reorders the TEST_CFLAGS options to match the CFLAGS options above for easier comparison.

test/concurrency: Fix unused arg warning from -Wall. Sort includes.

Feel free to reject this pull request since it doesnt really change anything. I just noticed it while making another change to the tests.