### PR TITLE
Deparser: Add parens around TypeCast in IndexElem

### DIFF
--- a/src/postgres_deparse.c
+++ b/src/postgres_deparse.c
@@ -1826,14 +1826,15 @@ static void deparseIndexElem(StringInfo str, IndexElem* index_elem)
 	{
 		switch (nodeTag(index_elem->expr))
 		{
-			case T_FuncCall:
-			case T_SQLValueFunction:
-			case T_TypeCast:
-			case T_CoalesceExpr:
-			case T_MinMaxExpr:
-			case T_XmlExpr:
-			case T_XmlSerialize:
+			// Simple function calls can be written without wrapping parens
+			case T_FuncCall: // func_application
+			case T_SQLValueFunction: // func_expr_common_subexpr
+			case T_CoalesceExpr: // func_expr_common_subexpr
+			case T_MinMaxExpr: // func_expr_common_subexpr
+			case T_XmlExpr: // func_expr_common_subexpr
+			case T_XmlSerialize: // func_expr_common_subexpr
 				deparseFuncExprWindowless(str, index_elem->expr);
+				appendStringInfoString(str, " ");
 				break;
 			default:
 				appendStringInfoChar(str, '(');

--- a/src/postgres_deparse.c
+++ b/src/postgres_deparse.c
@@ -29,6 +29,7 @@ typedef enum DeparseNodeContext {
 	DEPARSE_NODE_CONTEXT_CREATE_TYPE,
 	DEPARSE_NODE_CONTEXT_ALTER_TYPE,
 	DEPARSE_NODE_CONTEXT_SET_STATEMENT,
+	DEPARSE_NODE_CONTEXT_FUNC_EXPR,
 	// Identifier vs constant context
 	DEPARSE_NODE_CONTEXT_IDENTIFIER,
 	DEPARSE_NODE_CONTEXT_CONSTANT
@@ -1782,7 +1783,7 @@ static void deparseFuncExprWindowless(StringInfo str, Node* node)
 			deparseSQLValueFunction(str, castNode(SQLValueFunction, node));
 			break;
 		case T_TypeCast:
-			deparseTypeCast(str, castNode(TypeCast, node), DEPARSE_NODE_CONTEXT_NONE);
+			deparseTypeCast(str, castNode(TypeCast, node), DEPARSE_NODE_CONTEXT_FUNC_EXPR);
 			break;
 		case T_CoalesceExpr:
 			deparseCoalesceExpr(str, castNode(CoalesceExpr, node));
@@ -3546,7 +3547,7 @@ static void deparseTypeCast(StringInfo str, TypeCast *type_cast, DeparseNodeCont
 
 	Assert(type_cast->typeName != NULL);
 
-	if (IsA(type_cast->arg, A_Expr))
+	if (IsA(type_cast->arg, A_Expr) || context == DEPARSE_NODE_CONTEXT_FUNC_EXPR)
 	{
 		appendStringInfoString(str, "CAST(");
 		deparseExpr(str, type_cast->arg);

--- a/test/deparse_tests.c
+++ b/test/deparse_tests.c
@@ -406,6 +406,7 @@ const char* tests[] = {
   "ALTER TABLE a DISABLE TRIGGER b",
   "ALTER TABLE a DISABLE TRIGGER ALL",
   "ALTER TABLE a DISABLE TRIGGER USER",
+  "CREATE INDEX myindex ON public.mytable USING btree (col1, (col2::varchar) varchar_pattern_ops)"
 };
 
 size_t testsLength = __LINE__ - 4;

--- a/test/deparse_tests.c
+++ b/test/deparse_tests.c
@@ -406,7 +406,8 @@ const char* tests[] = {
   "ALTER TABLE a DISABLE TRIGGER b",
   "ALTER TABLE a DISABLE TRIGGER ALL",
   "ALTER TABLE a DISABLE TRIGGER USER",
-  "CREATE INDEX myindex ON public.mytable USING btree (col1, (col2::varchar) varchar_pattern_ops)"
+  "CREATE INDEX myindex ON public.mytable USING btree (col1, (col2::varchar) varchar_pattern_ops)",
+  "SELECT * FROM CAST(1 AS text)"
 };
 
 size_t testsLength = __LINE__ - 4;


### PR DESCRIPTION
We were incorrectly omitting these parentheses, as well as missing a space outputting "CREATE INDEX ON t (col::typecastops_class)" instead of "CREATE INDEX ON t ((col::typecast) ops_class)".

Fixes #213