### PR TITLE
Fix: ar variable in Makefile to inherit upstream ar command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ CLEANLIBS = $(ARLIB)
 CLEANOBJS = $(OBJ_FILES)
 CLEANFILES = $(PGDIRBZ2)
 
+AR ?= ar
 AR := $(AR) rs
 INSTALL = install
 LN_S = ln -s

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ CLEANLIBS = $(ARLIB)
 CLEANOBJS = $(OBJ_FILES)
 CLEANFILES = $(PGDIRBZ2)
 
-AR = ar rs
+AR := $(AR) rs
 INSTALL = install
 LN_S = ln -s
 RM = rm -f


### PR DESCRIPTION
Fantastic library!

I'm working on compiling this library to WASM using Emscripten (specifically for [libpg-query-node](https://github.com/pyramation/libpg-query-node)). Emscripten has a command `emmake` that simply wraps `make` with `CC`, `CXX`, `AR`, etc set to the Emscripten drop-in replacements (`emcc`, `em++`, `emar`).

Surprisingly running `emmake make` on this repository's `Makefile` JustWorked™ with the exception of a one-line change to the `Makefile` which is what this PR proposes.

We just need to replace the hardcoded `AR` variable:
```
AR = ar rs
```

with a reference to the upstream inherited `AR` variable:

```
AR := $(AR) rs
```

so that Emscripten's `emar` replacement is used.

Let me know if you have any questions or need any more clarification.