### PR TITLE
Use "-std=gnu99" by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ override PG_CONFIGURE_FLAGS += -q --without-readline --without-zlib
 override TEST_CFLAGS += -g -I. -I./vendor -Wall
 override TEST_LDFLAGS += -pthread
 
+override CFLAGS += -std=gnu99
+override TEST_CFLAGS += -std=gnu99
+
 CFLAGS_OPT_LEVEL = -O3
 ifeq ($(DEBUG),1)
 	CFLAGS_OPT_LEVEL = -O0


### PR DESCRIPTION
I get the following error on centos7
![1](https://github.com/SunBeau/libpg_query/assets/26088422/bca93e7c-e893-4f56-a3a2-23a1be4753c0)
get another error as follows, if set -std=c99
![2](https://github.com/SunBeau/libpg_query/assets/26088422/9028a2af-6b1b-4cc0-9b87-275ec345b175)
it will be ok, if set -std=gnu99.
so i think that it should use "-std=gnu99" by default.
Related question: https://github.com/pganalyze/libpg_query/issues/169