### PR TITLE
Fix type cast for normalizing alter subscription statement

### DIFF
--- a/src/pg_query_normalize.c
+++ b/src/pg_query_normalize.c
@@ -417,7 +417,7 @@ static bool const_record_walker(Node *node, pgssConstLocations *jstate)
 			record_matching_string(jstate, ((CreateSubscriptionStmt *) node)->conninfo);
 			break;
 		case T_AlterSubscriptionStmt:
-			record_matching_string(jstate, ((CreateSubscriptionStmt *) node)->conninfo);
+			record_matching_string(jstate, ((AlterSubscriptionStmt *) node)->conninfo);
 			break;
 		case T_CreateUserMappingStmt:
 			return const_record_walker((Node *) ((CreateUserMappingStmt *) node)->options, jstate);


### PR DESCRIPTION
I am compiling this library to WebAssembly and ran into this issue. This test failed for me

https://github.com/pganalyze/libpg_query/blob/15-latest/test/normalize_tests.c#L30

The bug is obvious, though I'm not sure what it is about the WebAssembly toolchain that causes it to break vs how these tests are normally run, it could be the usage of musl as libc or just the LLVM Wasm backend itself.