### PR TITLE
Fix: ar variable in Makefile (back patch to v13)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ CLEANLIBS = $(ARLIB)
 CLEANOBJS = $(OBJ_FILES)
 CLEANFILES = $(PGDIRBZ2)
 
-AR = ar rs
+AR ?= ar
+AR := $(AR) rs
 INSTALL = install
 LN_S = ln -s
 RM = rm -f


### PR DESCRIPTION
Applies the same patch as https://github.com/pganalyze/libpg_query/pull/217 but to v13 (in order to use in v13 version of [libpg-query-node](https://github.com/pyramation/libpg-query-node)).

Replaces the hardcoded `AR` variable:
```
AR = ar rs
```

with a reference to the upstream inherited `AR` variable:

```
AR ?= ar
AR := $(AR) rs
```

so that Emscripten's `emar` replacement is used.