### PR TITLE
Fix cursor quoting in FetchStmt

### DIFF
--- a/src/postgres_deparse.c
+++ b/src/postgres_deparse.c
@@ -8707,7 +8707,7 @@ static void deparseFetchStmt(StringInfo str, FetchStmt *fetch_stmt)
 			appendStringInfo(str, "RELATIVE %ld ", fetch_stmt->howMany);
 	}
 
-	appendStringInfoString(str, fetch_stmt->portalname);
+	appendStringInfoString(str, quote_identifier(fetch_stmt->portalname));
 }
 
 static void deparseAlterDefaultPrivilegesStmt(StringInfo str, AlterDefaultPrivilegesStmt *alter_default_privileges_stmt)

--- a/test/deparse_tests.c
+++ b/test/deparse_tests.c
@@ -407,7 +407,9 @@ const char* tests[] = {
   "ALTER TABLE a DISABLE TRIGGER ALL",
   "ALTER TABLE a DISABLE TRIGGER USER",
   "CREATE INDEX myindex ON public.mytable USING btree (col1, (col2::varchar) varchar_pattern_ops)",
-  "SELECT * FROM CAST(1 AS text)"
+  "SELECT * FROM CAST(1 AS text)",
+  "DECLARE \"Foo1\" SCROLL CURSOR FOR SELECT * FROM tenk1 ORDER BY unique2",
+  "FETCH BACKWARD 23 \"Foo1\""
 };
 
 size_t testsLength = __LINE__ - 4;

--- a/test/sql/postgres_regress/portals.sql
+++ b/test/sql/postgres_regress/portals.sql
@@ -4,7 +4,7 @@
 
 BEGIN;
 
-DECLARE foo1 SCROLL CURSOR FOR SELECT * FROM tenk1 ORDER BY unique2;
+DECLARE "Foo1" SCROLL CURSOR FOR SELECT * FROM tenk1 ORDER BY unique2;
 
 DECLARE foo2 SCROLL CURSOR FOR SELECT * FROM tenk2;
 
@@ -50,7 +50,7 @@ DECLARE foo22 SCROLL CURSOR FOR SELECT * FROM tenk2;
 
 DECLARE foo23 SCROLL CURSOR FOR SELECT * FROM tenk1 ORDER BY unique2;
 
-FETCH 1 in foo1;
+FETCH 1 in "Foo1";
 
 FETCH 2 in foo2;
 
@@ -140,9 +140,9 @@ FETCH backward 21 in foo3;
 
 FETCH backward 22 in foo2;
 
-FETCH backward 23 in foo1;
+FETCH backward 23 in "Foo1";
 
-CLOSE foo1;
+CLOSE "Foo1";
 
 CLOSE foo2;
 

--- a/test/sql/postgres_regress/portals.sql
+++ b/test/sql/postgres_regress/portals.sql
@@ -4,7 +4,7 @@
 
 BEGIN;
 
-DECLARE "Foo1" SCROLL CURSOR FOR SELECT * FROM tenk1 ORDER BY unique2;
+DECLARE foo1 SCROLL CURSOR FOR SELECT * FROM tenk1 ORDER BY unique2;
 
 DECLARE foo2 SCROLL CURSOR FOR SELECT * FROM tenk2;
 
@@ -50,7 +50,7 @@ DECLARE foo22 SCROLL CURSOR FOR SELECT * FROM tenk2;
 
 DECLARE foo23 SCROLL CURSOR FOR SELECT * FROM tenk1 ORDER BY unique2;
 
-FETCH 1 in "Foo1";
+FETCH 1 in foo1;
 
 FETCH 2 in foo2;
 
@@ -140,9 +140,9 @@ FETCH backward 21 in foo3;
 
 FETCH backward 22 in foo2;
 
-FETCH backward 23 in "Foo1";
+FETCH backward 23 in foo1;
 
-CLOSE "Foo1";
+CLOSE foo1;
 
 CLOSE foo2;
 


### PR DESCRIPTION
Regression tests updated to test all cursor related statement with a name that requires quoting.