### PR TITLE
Allow alternate definitions of NAMEDATALEN identifier limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ $(PGDIR):
 	cd $(PGDIR); patch -p1 < $(root_dir)/patches/08_avoid_zero_length_delimiter_in_regression_tests.patch
 	cd $(PGDIR); patch -p1 < $(root_dir)/patches/09_allow_param_junk.patch
 	cd $(PGDIR); patch -p1 < $(root_dir)/patches/10_avoid_namespace_hashtab_impl_gen.patch
+	cd $(PGDIR); patch -p1 < $(root_dir)/patches/11_ifndef_namedatalen.patch
 	cd $(PGDIR); ./configure $(PG_CONFIGURE_FLAGS)
 	cd $(PGDIR); make -C src/pl/plpgsql/src pl_gram.h plerrcodes.h pl_reserved_kwlist_d.h pl_unreserved_kwlist_d.h
 	cd $(PGDIR); make -C src/port pg_config_paths.h

--- a/patches/11_ifndef_namedatalen.patch
+++ b/patches/11_ifndef_namedatalen.patch
@@ -1,0 +1,14 @@
+diff --git a/src/include/pg_config_manual.h b/src/include/pg_config_manual.h
+index a1a93ad..c978d76 100644
+--- a/src/include/pg_config_manual.h
++++ b/src/include/pg_config_manual.h
+@@ -26,7 +26,9 @@
+  *
+  * Changing this requires an initdb.
+  */
++#ifndef NAMEDATALEN
+ #define NAMEDATALEN 64
++#endif
+
+ /*
+  * Maximum number of arguments to a function.

--- a/src/postgres/include/pg_config_manual.h
+++ b/src/postgres/include/pg_config_manual.h
@@ -26,7 +26,9 @@
  *
  * Changing this requires an initdb.
  */
+#ifndef NAMEDATALEN
 #define NAMEDATALEN 64
+#endif
 
 /*
  * Maximum number of arguments to a function.


### PR DESCRIPTION
## What

This PR surrounds the definition of the [`NAMEDATALEN` constant](https://www.postgresql.org/docs/16/runtime-config-preset.html#GUC-MAX-IDENTIFIER-LENGTH) with an `#ifndef`.

## Why

Increasing `NAMEDATALEN` allows you to, for example, avoid the truncation normally produced by the postgres parser on this 65 character identifier:

```sql
SELECT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa12345
```
```diff
{
  "stmts": [
    {
      "stmt": {
        "SelectStmt": {
          "limitOption": "LIMIT_OPTION_DEFAULT",
          "op": "SETOP_NONE",
          "targetList": [
            {
              "ResTarget": {
                "location": 7,
                "val": {
                  "ColumnRef": {
                    "fields": [
                      {
                        "String": {
- "sval": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa123"
+ "sval": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa12345"
                        }
                      }
                    ],
                    "location": 7
                  }
                }
              }
            }
          ]
        }
      }
    }
  ],
  "version": 150001
}
```

## Notes

To generate this PR and validate it, I needed to run `make extract_source`.

To get `make extract_source` working, I needed these 3 pre-requisites:

1. macOS.
    - There is [an invocation](https://github.com/pganalyze/libpg_query/blob/d49cc8e1ffe412d67d3dbae6c7020a35edacbe93/scripts/extract_source.rb#L220) of [`xcrun`](https://apple.stackexchange.com/a/432153) inside of [`extract_source.rb`](https://github.com/pganalyze/libpg_query/blob/d49cc8e1ffe412d67d3dbae6c7020a35edacbe93/scripts/extract_source.rb#L220).
    - [Non-portable (macOS specific) `sed -i ""` invocations](https://stackoverflow.com/a/4247319) peppered throughout `Makefile` ([example](https://github.com/pganalyze/libpg_query/blob/d49cc8e1ffe412d67d3dbae6c7020a35edacbe93/Makefile#L140)).
    - I used the most recent version of macOS Sonoma.
2. ruby `3.1.2`.
3. gem `ffi-clang 0.8.0`
    - `gem install ffi-clang --version'0.8.0'`
    - I did not see the `ffi-clang` requirement pinned or documented anywhere, but versions of `ffi-clang` newer than `0.8.0` move the `visit_children` method and cause a runtime error in `extract_source.rb`:
```ruby
extract_source.rb:260:in `analyze_file': undefined method `visit_children' for an instance of FFI::Clang::Cursor (NoMethodError)

    cursor.visit_children do |cursor, parent|
          ^^^^^^^^^^^^^^^
```