### PR TITLE
Fix: deparse DEFAULT in ColumnDef `AT TIME ZONE`

### DIFF
--- a/test/deparse_tests.c
+++ b/test/deparse_tests.c
@@ -409,7 +409,10 @@ const char* tests[] = {
   "CREATE INDEX myindex ON public.mytable USING btree (col1, (col2::varchar) varchar_pattern_ops)",
   "SELECT * FROM CAST(1 AS text)",
   "DECLARE \"Foo1\" SCROLL CURSOR FOR SELECT * FROM tenk1 ORDER BY unique2",
-  "FETCH BACKWARD 23 \"Foo1\""
+  "FETCH BACKWARD 23 \"Foo1\"",
+  "CREATE TABLE my_table (created_at timestamptz NOT NULL DEFAULT (current_timestamp AT TIME ZONE 'UTC'))",
+  "CREATE TABLE my_table (created_at timestamptz NOT NULL DEFAULT (now() AT TIME ZONE 'UTC'))",
+  "CREATE TABLE my_table (created_at timestamptz NOT NULL DEFAULT (now() AT LOCAL))"
 };
 
 size_t testsLength = __LINE__ - 4;


### PR DESCRIPTION
I submitted a bug report earlier today in the [pg_query_go issues](https://github.com/pganalyze/pg_query_go/issues/126), then decided to have a look and see if I could fix it.

This fixes a bug in which DEFAULT expressions are deparsed into invalid SQL.

I added test cases to `deparse_tests.c`, which are corrected in the suggested fix.

I'm not sure about whether my manner of detecting the situation will suit you, but I hope we can get something going here in the way of a fix.  I'm trying to release some software that depends on being able to deparse queries of this shape, and am going to have to, for the time being, devise some kind of workaround in order to ship.

Thanks!  Let me know if I can help in any way.
