### PR TITLE
fix the null pointer dereference

### DIFF
--- a/src/postgres_deparse.c
+++ b/src/postgres_deparse.c
@@ -1524,6 +1524,8 @@ static void deparseAlterIdentityColumnOptionList(StringInfo str, List *l)
 		else if (strcmp(def_elem->defname, "generated") == 0)
 		{
 			appendStringInfoString(str, "SET GENERATED ");
+			if(def_elem->arg == NULL)
+				elog(ERROR, "missing argument for identity generation specification");
 			if (intVal(def_elem->arg) == ATTRIBUTE_IDENTITY_ALWAYS)
 				appendStringInfoString(str, "ALWAYS");
 			else if (intVal(def_elem->arg) == ATTRIBUTE_IDENTITY_BY_DEFAULT)

--- a/src/postgres_deparse.c
+++ b/src/postgres_deparse.c
@@ -1524,8 +1524,8 @@ static void deparseAlterIdentityColumnOptionList(StringInfo str, List *l)
 		else if (strcmp(def_elem->defname, "generated") == 0)
 		{
 			appendStringInfoString(str, "SET GENERATED ");
-			if(def_elem->arg == NULL)
-				elog(ERROR, "missing argument for identity generation specification");
+			if (def_elem->arg == NULL)
+				elog(ERROR, "deparse: missing argument for identity generation specification");
 			if (intVal(def_elem->arg) == ATTRIBUTE_IDENTITY_ALWAYS)
 				appendStringInfoString(str, "ALWAYS");
 			else if (intVal(def_elem->arg) == ATTRIBUTE_IDENTITY_BY_DEFAULT)


### PR DESCRIPTION
The NULL Dereference vulnerability happens in `static void deparseAlterIdentityColumnOptionList ()`, `src/postgres_deparse.c`
How the NULL Pointer Dereference happens:
1. When `strcmp(def_elem->defname, "generated") == 0` and `def_elem->arg == NULL`
2. NULL dereference of variable `def_elem->arg happens` at `(castNode(Integer, v)->ival)`
```
static void deparseAlterIdentityColumnOptionList(StringInfo str, List *l)
{
    ListCell *lc = NULL;
    foreach (lc, l)
    {
        DefElem *def_elem = castNode(DefElem, lfirst(lc));
        ......
        else if (strcmp(def_elem->defname, "generated") == 0)
        {
            appendStringInfoString(str, "SET GENERATED ");
=>          if (intVal(def_elem->arg) == ATTRIBUTE_IDENTITY_ALWAYS)
                appendStringInfoString(str, "ALWAYS");
            ......
        }
    }
    ......
}

=>  #define intVal(v)       (castNode(Integer, v)->ival)
```