### PR TITLE
Update GitHub Actions Linux OS to 24.04 for 15-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         valgrind: [valgrind,no-valgrind]
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Cache protobuf library
       if: matrix.protobuf_lib == 'protobuf-cpp'
       id: cache-protobuf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         compiler: [clang, gcc]
         protobuf_lib: [protobuf-c, protobuf-cpp]
         valgrind: [valgrind,no-valgrind]
+        exclude:
+          # this combination hits linking errors: see https://github.com/pganalyze/libpg_query/pull/289
+          - compiler: clang
+            protobuf_lib: protobuf-cpp
+            valgrind: valgrind
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -21,7 +26,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: protobuf-3.14.0
-        key: ${{ runner.os }}-protobuf-cpp-3.14.0
+        key: ${{ runner.os }}-${{ matrix.compiler }}-protobuf-cpp-3.14.0
     - name: Build protobuf library
       if: matrix.protobuf_lib == 'protobuf-cpp' && steps.cache-protobuf.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Cache protobuf library
       if: matrix.protobuf_lib == 'protobuf-cpp'
       id: cache-protobuf
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: protobuf-3.14.0
         key: ${{ runner.os }}-protobuf-cpp-3.14.0


### PR DESCRIPTION
To support this, merge some of the ci.yml changes from 17-latest:

 - GH actions: Update to actions/checkout@v4
 - Update GH actions cache module to v4
 - Update GitHub Actions Linux OS to 24.04 (#289)
