### PR TITLE
Add pgsqlparser for .NET to README - full fledged wrapper on libpg_query

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ C library for accessing the PostgreSQL parser outside of the server.
 
 This library uses the actual PostgreSQL server source to parse SQL queries and return the internal PostgreSQL parse tree.
 
-Note that this is mostly intended as a base library for [pg_query](https://github.com/pganalyze/pg_query) (Ruby), [pg_query.go](https://github.com/pganalyze/pg_query_go) (Go), [pg_query.rs](https://github.com/pganalyze/pg_query.rs) (Rust), [pgsql-parser](https://github.com/launchql/pgsql-parser) (Node), [psqlparse](https://github.com/alculquicondor/psqlparse) (Python) and [pglast](https://pypi.org/project/pglast/) (Python 3).
+Note that this is mostly intended as a base library for [pg_query](https://github.com/pganalyze/pg_query) (Ruby), [pg_query.go](https://github.com/pganalyze/pg_query_go) (Go), [pg_query.rs](https://github.com/pganalyze/pg_query.rs) (Rust), [pgsql-parser](https://github.com/launchql/pgsql-parser) (Node), [psqlparse](https://github.com/alculquicondor/psqlparse) (Python), [pglast](https://pypi.org/project/pglast/) (Python 3) and [pgsqlparser](https://github.com/mysticmind/pgsqlparser-dotnet) (.NET).
 
 You can find further background to why a query's parse tree is useful here: https://pganalyze.com/blog/parse-postgresql-queries-in-ruby.html
 
@@ -261,6 +261,7 @@ pg_query wrappers in other languages:
 [psqlparse2](https://github.com/dani-maarouf/psqlparse2)
 * OCaml: [pg_query-ocaml](https://github.com/roddyyaga/pg_query-ocaml)
 * Rust: [pg_query.rs](https://github.com/pganalyze/pg_query.rs)
+* .NET: [pgsqlparser](https://github.com/mysticmind/pgsqlparser-dotnet)
 
 Products, tools and libraries built on pg_query:
 


### PR DESCRIPTION
Add pgsqlparser for .NET to README - a full fledged wrapper on libpg_query.

With reference to my other PR https://github.com/pganalyze/libpg_query/pull/296, this is the cross platform .NET wrapper which I was indicating there.