### PR TITLE
Fix compilation warnings for the examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ int main() {
   printf("%s\n", result.parse_tree);
 
   pg_query_free_parse_result(result);
+
+  return 0;
 }
 ```
 
@@ -110,9 +112,9 @@ int main() {
   const char *input = "SELECT update AS left /* comment */ FROM between";
 
   result = pg_query_scan(input);
-  scan_result = pg_query__scan_result__unpack(NULL, result.pbuf.len, (void *) result.pbuf.data);
+  scan_result = pg_query__scan_result__unpack(NULL, result.pbuf.len, (const uint8_t *) result.pbuf.data);
 
-  printf("  version: %d, tokens: %ld, size: %d\n", scan_result->version, scan_result->n_tokens, result.pbuf.len);
+  printf("  version: %d, tokens: %ld, size: %zu\n", scan_result->version, scan_result->n_tokens, result.pbuf.len);
   for (size_t j = 0; j < scan_result->n_tokens; j++) {
     scan_token = scan_result->tokens[j];
     token_kind = protobuf_c_enum_descriptor_get_value(&pg_query__token__descriptor, scan_token->token);
@@ -174,6 +176,8 @@ int main() {
   printf("%s\n", result.fingerprint_str);
 
   pg_query_free_fingerprint_result(result);
+
+  return 0;
 }
 ```
 


### PR DESCRIPTION
I noticed a couple of warnings when compiling the examples from `README.md`
Please consider merging my changes or tell me how to make the PR better