### PR TITLE
Speed up summary truncate replacement logic

### DIFF
--- a/src/pg_query_summary_truncate.c
+++ b/src/pg_query_summary_truncate.c
@@ -285,26 +285,21 @@ cmp_possible_truncations(const ListCell *a, const ListCell *b)
 static void
 global_replace(char *str, char *pattern, char *replacement)
 {
-	size_t		plen = strlen(pattern);
-	size_t		rlen = strlen(replacement);
-	size_t		slen = strlen(str);
+	size_t plen = strlen(pattern);
+	size_t rlen = strlen(replacement);
+	char *s = str;
 
 	Assert(plen >= rlen);
 
-	for (size_t i = 0; i < slen; i++)
+	while ((s = strstr(s, pattern)) != NULL)
 	{
-		if (memcmp(str + i, pattern, plen) == 0)
-		{
-			memcpy(str + i, replacement, rlen);
+		memcpy(s, replacement, rlen);
 
-			// Shift remainder of the string if needed
-			if (plen > rlen)
-			{
-				size_t skip = i + plen;
-				memmove(str + i + rlen, str + skip, slen - skip + 1);
-				slen -= (plen - rlen);
-			}
-		}
+		// Shift remainder of the string if needed
+		if (plen > rlen)
+			memmove(s + rlen, s + plen, strlen(s + plen) + 1);
+
+		s += rlen;
 	}
 }
 

--- a/src/pg_query_summary_truncate.c
+++ b/src/pg_query_summary_truncate.c
@@ -285,9 +285,9 @@ cmp_possible_truncations(const ListCell *a, const ListCell *b)
 static void
 global_replace(char *str, char *pattern, char *replacement)
 {
-	size_t plen = strlen(pattern);
-	size_t rlen = strlen(replacement);
-	char *s = str;
+	size_t		plen = strlen(pattern);
+	size_t		rlen = strlen(replacement);
+	char	   *s = str;
 
 	Assert(plen >= rlen);
 
@@ -295,7 +295,7 @@ global_replace(char *str, char *pattern, char *replacement)
 	{
 		memcpy(s, replacement, rlen);
 
-		// Shift remainder of the string if needed
+		/* Shift remainder of the string if needed */
 		if (plen > rlen)
 			memmove(s + rlen, s + plen, strlen(s + plen) + 1);
 

--- a/src/pg_query_summary_truncate.c
+++ b/src/pg_query_summary_truncate.c
@@ -287,15 +287,23 @@ global_replace(char *str, char *pattern, char *replacement)
 {
 	size_t		plen = strlen(pattern);
 	size_t		rlen = strlen(replacement);
+	size_t		slen = strlen(str);
 
-	for (size_t i = 0; i < strlen(str); i++)
+	Assert(plen >= rlen);
+
+	for (size_t i = 0; i < slen; i++)
 	{
 		if (memcmp(str + i, pattern, plen) == 0)
 		{
-			size_t		len = strlen(str + i + plen);
-
 			memcpy(str + i, replacement, rlen);
-			memmove(str + i + rlen, str + i + plen, len + 1);
+
+			// Shift remainder of the string if needed
+			if (plen > rlen)
+			{
+				size_t skip = i + plen;
+				memmove(str + i + rlen, str + skip, slen - skip + 1);
+				slen -= (plen - rlen);
+			}
 		}
 	}
 }


### PR DESCRIPTION
This was calling strlen on every iteration of the loop, causing excessive runtime on deeply nested queries (e.g. hundreds of UNION ALL).

In passing, make explicit an assumption that the replacement string is as long, or shorter, than the pattern we're matching against.