### PR TITLE
Build: Limit shared library exports to the documented public API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,15 @@ ifeq ($(shell uname -s), Darwin)
 	SONAME = lib$(TARGET).$(SO_VERSION).dylib
 	SOLIBVER = lib$(TARGET).$(SO_VERSION).$(VERSION_PATCH).dylib
 	SOFLAG = -install_name
+	SO_EXPORTS = -Wl,-exported_symbols_list,$(root_dir)/pg_query.exp
+	SO_EXPORTS_FILE = pg_query.exp
 else
 	SOLIB = lib$(TARGET).so
 	SONAME = $(SOLIB).$(SO_VERSION)
 	SOLIBVER = $(SONAME).$(VERSION_PATCH)
 	SOFLAG = -soname
+	SO_EXPORTS = -Wl,--version-script=$(root_dir)/pg_query.map
+	SO_EXPORTS_FILE = pg_query.map
 endif
 
 SRC_FILES := $(wildcard src/*.c src/postgres/*.c) vendor/protobuf-c/protobuf-c.c vendor/xxhash/xxhash.c protobuf/pg_query.pb-c.c
@@ -190,8 +194,8 @@ extract_source: $(PGDIR)
 $(ARLIB): $(OBJ_FILES) Makefile
 	@$(AR) $(ARFLAGS) $@ $(OBJ_FILES)
 
-$(SOLIB): $(OBJ_FILES) Makefile
-	@$(CC) $(CFLAGS) -shared -Wl,$(SOFLAG),$(SONAME) $(LDFLAGS) -o $@ $(OBJ_FILES) $(LIBS)
+$(SOLIB): $(OBJ_FILES) Makefile $(SO_EXPORTS_FILE)
+	@$(CC) $(CFLAGS) -shared -Wl,$(SOFLAG),$(SONAME) $(SO_EXPORTS) $(LDFLAGS) -o $@ $(OBJ_FILES) $(LIBS)
 
 protobuf/pg_query.pb-c.c protobuf/pg_query.pb-c.h: protobuf/pg_query.proto
 ifneq ($(shell which protoc-gen-c), )

--- a/pg_query.exp
+++ b/pg_query.exp
@@ -1,0 +1,5 @@
+# Mach-O exported symbols list, companion to pg_query.map for ELF.
+# Mach-O prefixes C symbols with a leading underscore.
+_pg_query_*
+_deparseRawStmt
+_deparseRawStmtOpts

--- a/pg_query.map
+++ b/pg_query.map
@@ -1,0 +1,12 @@
+# GNU ld version script. Restricts the libpg_query shared library to the
+# documented public API (pg_query.h, postgres_deparse.h) and hides bundled
+# PostgreSQL internals so they don't conflict when libpg_query is embedded
+# inside a PostgreSQL extension (TLS vs non-TLS CurrentMemoryContext).
+{
+    global:
+        pg_query_*;
+        deparseRawStmt;
+        deparseRawStmtOpts;
+    local:
+        *;
+};


### PR DESCRIPTION
## Summary

`libpg_query.so` / `.dylib` exports its bundled PostgreSQL internals
(`palloc`, `pfree`, `lappend`, `MemoryContextSwitchTo`,
`CurrentMemoryContext`, ...) and the protobuf-c machinery in addition to
the documented `pg_query_*` / `deparseRawStmt` API — 2044 dynamic
exports vs. 1692 of public surface on a clean 17-6.2.2 build.

Restrict the `.so` / `.dylib` exports to the public API declared in
`pg_query.h` and `postgres_deparse.h`, via a GNU ld version script
(`pg_query.map`) on ELF and a Mach-O `exported_symbols_list`
(`pg_query.exp`) on macOS. The static library (`libpg_query.a`) is
unchanged.

## Why

Embedding libpg_query inside a PostgreSQL extension fails at link time:
the bundled `CurrentMemoryContext` / `TopMemoryContext` / `ErrorContext`
/ `error_context_stack` are `__thread` (so the parser is reentrant),
while the host PostgreSQL declares them non-TLS, and the linker rejects:

```
/usr/bin/ld: CurrentMemoryContext: TLS reference in libpg_query.so
  mismatches non-TLS reference in <ext>.o
```

Hiding the bundled globals lets each `.so` resolve its own copy at load
time. We hit this in a custom PG extension consuming libpg_query
([`ng-galien/esac`](https://github.com/ng-galien/esac)), where static
linking wasn't an option because the parser is shared across modules in
the same backend.

PostgreSQL core itself adopted the same approach for extension libraries
(commitfest #3396, "Default to hidden visibility for extension
libraries").

## Mechanism

* `pg_query.map` / `pg_query.exp` — whitelist `pg_query_*`,
  `deparseRawStmt`, `deparseRawStmtOpts`; everything else hidden.
* `Makefile` — picks the right file via `SO_EXPORTS` / `SO_EXPORTS_FILE`
  based on `uname -s`, wired into the `\$(SOLIB)` link line.

The `pg_query_*` wildcard covers the protobuf-c-generated symbols
(`pg_query__scan_result__unpack`, `pg_query__token__descriptor`, ...).

## Test plan

- [x] macOS (arm64) and Linux (debian:bookworm-slim, GNU ld 2.40):
      full `make` passes; `nm -D` / `nm -gU` on the resulting `.so` /
      `.dylib` shows only `pg_query_*` and `deparseRawStmt[Opts]`.
- [ ] Windows MSVC: N/A — `Makefile.msvc` has no shared-lib target.
- [ ] Windows MSYS2: shared-lib path not exercised in CI today
      (pre-existing).

**Note on AI tool use:** Claude Code drafted the linker scripts, Makefile
wiring and commit message; I steered it back to this repo's conventions
on review.