### PR TITLE
Avoid needing testLength for fingerprint tests.

### DIFF
--- a/test/fingerprint.c
+++ b/test/fingerprint.c
@@ -5,14 +5,17 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "fingerprint_tests.c"
-
 int main()
 {
+	char *tests[] = {
+#include "fingerprint_tests.c"
+		NULL
+	};
+
 	size_t i;
 	bool ret_code = 0;
 
-	for (i = 0; i < testsLength; i += 2)
+	for (i = 0; tests[i] != NULL; i += 2)
 	{
 		PgQueryFingerprintResult result = pg_query_fingerprint(tests[i]);
 
@@ -30,7 +33,7 @@ int main()
 		else
 		{
 			ret_code = -1;
-			printf("INVALID result for \"%s\"\nexpected: \"%s\"\nactual: \"%s\"\nactual tokens: ", tests[i], tests[i + 1], result.fingerprint_str);
+			printf("\n\nINVALID result for \"%s\"\nexpected: \"%s\"\nactual: \"%s\"\nactual tokens: ", tests[i], tests[i + 1], result.fingerprint_str);
 			pg_query_fingerprint_with_opts(tests[i], PG_QUERY_PARSE_DEFAULT, true);
 		}
 

--- a/test/fingerprint_tests.c
+++ b/test/fingerprint_tests.c
@@ -1,4 +1,3 @@
-const char* tests[] = {
   "SELECT 1",
   "50fde20626009aba",
   "SELECT 2",
@@ -196,6 +195,3 @@ const char* tests[] = {
   "1a16559b625d7498",
   "ALTER TABLE baz.bar ADD COLUMN c int",
   "2f36adf7ba9689b8",
-};
-
-const size_t testsLength = sizeof(tests)/sizeof(*tests)/2;


### PR DESCRIPTION
This was being calculated wrong, and thus not all tests were running.

Unfortunately, there are now failing tests.

`tests/fingerprint_tests.c` is now indented wrong, but I felt it made sense to get the tests working before re-indenting that, to keep the diff as small as possible.