### PR TITLE
Use strlcpy instead of strncpy in deparser/summary truncate

### DIFF
--- a/src/pg_query_summary_truncate.c
+++ b/src/pg_query_summary_truncate.c
@@ -85,8 +85,7 @@ truncate_mbstr(char *mbstr, size_t max_chars)
 	int			n_bytes = pg_mbcharcliplen(mbstr, strlen(mbstr), max_chars - 3);
 
 	/* Actually truncate it. */
-	strncpy(mbstr + n_bytes, "...", 4);
-	mbstr[n_bytes + 3] = '\0';
+	strlcpy(mbstr + n_bytes, "...", 4);
 }
 
 static void

--- a/src/postgres_deparse.c
+++ b/src/postgres_deparse.c
@@ -1879,8 +1879,7 @@ bool optBooleanValue(Node *node)
 		case T_String: {
 			// Longest valid string is "off\0"
 			char lower[4];
-			strncpy(lower, strVal(node), 4);
-			lower[3] = 0;
+			strlcpy(lower, strVal(node), sizeof(lower));
 
 			if (strcmp(lower, "on") == 0) {
 				return true;


### PR DESCRIPTION
Recent removal of use of strncpy in the Linux kernel reminded me that we can reliably use the safer strlcpy function (which null terminates), since Postgres has a compatibility wrapper for systems that don't have a built-in. Postgres itself has preferred use of strlcpy over strncpy since at least 2006, see upstream commit [c92f7e258ee](https://github.com/postgres/postgres/commit/c92f7e258ee), although a few uses are still present that we retain from upstream code copying.