### PR TITLE
Normalize: Avoid undefined behaviour for overly large parameter value

### DIFF
--- a/src/pg_query_normalize.c
+++ b/src/pg_query_normalize.c
@@ -255,8 +255,8 @@ generate_normalized_query(pgssConstLocations *jstate, int query_loc, int* query_
 	for (i = 0; i < jstate->clocations_count; i++)
 	{
 		int			off,		/* Offset from start for cur tok */
-					tok_len,	/* Length (in bytes) of that tok */
-					param_id;	/* Param ID to be assigned */
+					tok_len;	/* Length (in bytes) of that tok */
+		int64_t		param_id;	/* Param ID to be assigned */
 
 		off = jstate->clocations[i].location;
 		/* Adjust recorded location if we're dealing with partial string */
@@ -277,9 +277,9 @@ generate_normalized_query(pgssConstLocations *jstate, int query_loc, int* query_
 
 		/* And insert a param symbol in place of the constant token */
 		param_id = (jstate->clocations[i].param_id < 0) ?
-					jstate->highest_extern_param_id + abs(jstate->clocations[i].param_id) :
+					(int64_t) jstate->highest_extern_param_id + abs(jstate->clocations[i].param_id) :
 					jstate->clocations[i].param_id;
-		n_quer_loc += sprintf(norm_query + n_quer_loc, "$%d", param_id);
+		n_quer_loc += sprintf(norm_query + n_quer_loc, "$" INT64_FORMAT, param_id);
 
 		quer_loc = off + tok_len;
 		last_off = off;

--- a/test/normalize_tests.c
+++ b/test/normalize_tests.c
@@ -52,6 +52,8 @@ const char* tests[] = {
   "CLOSE cursor_a",
   "SELECT 1; ALTER USER a WITH PASSWORD 'b'",
   "SELECT $1; ALTER USER a WITH PASSWORD $2",
+  "SELECT 3,$2147483647",
+  "SELECT $2147483648,$2147483647",
 };
 
 size_t testsLength = __LINE__ - 7;

--- a/test/normalize_utility_tests.c
+++ b/test/normalize_utility_tests.c
@@ -53,6 +53,8 @@ const char* tests[] = {
   "CLOSE cursor_a",
   "SELECT 1; ALTER USER a WITH PASSWORD 'b'",
   "SELECT 1; ALTER USER a WITH PASSWORD $1",
+  "SELECT 3,$2147483647",
+  "SELECT 3,$2147483647",
 };
 
 size_t testsLength = __LINE__ - 8;


### PR DESCRIPTION
Whilst Postgres itself in practice only allows 65,535 usable parameters, we take arbitrary input for the normalize function, and the parser itself allows up to INT_MAX values. This leads to undefined behavior when $2147483647 (INT_MAX) is used as a parameter reference, together with a value, and generate_normalized_query tries to assign INT_MAX + 1 as the parameter number. Fix by using a 64-bit integer value for calculating the next parameter number to assign.

Per UBSAN report from OSS-Fuzz.