### PR TITLE
Normalize: Fix handling of &U special constants in DefElem nodes

### DIFF
--- a/src/pg_query_normalize.c
+++ b/src/pg_query_normalize.c
@@ -348,11 +348,26 @@ static bool is_special_string_start(char c)
 
 static void record_defelem_arg_location(pgssConstLocations *jstate, int location)
 {
-	for (int i = location; i < jstate->query_len; i++) {
-		if (is_string_delimiter(jstate->query[i]) || (i + 1 < jstate->query_len && is_special_string_start(jstate->query[i]) && is_string_delimiter(jstate->query[i + 1]))) {
-			RecordConstLocation(jstate, i);
-			break;
-		}
+	for (int i = location; i < jstate->query_len; i++)
+	{
+		if (!is_string_delimiter(jstate->query[i]))
+			continue;
+
+		/*
+		 * Step back over tokens that affect the string constant, placed right
+		 * before the opening quote, so the recorded location includes those
+		 * tokens. "U&" for a Unicode escaped strings, or a single character
+		 * special start token matched by is_special_string_start.
+		 */
+		if (i - 2 >= location && jstate->query[i - 1] == '&' &&
+			(jstate->query[i - 2] == 'u' || jstate->query[i - 2] == 'U'))
+			i -= 2;
+		else if (i - 1 >= location && is_special_string_start(jstate->query[i - 1]))
+			i -= 1;
+
+		RecordConstLocation(jstate, i);
+
+		break;
 	}
 }
 

--- a/test/normalize_tests.c
+++ b/test/normalize_tests.c
@@ -42,6 +42,8 @@ const char* tests[] = {
   "MERGE into measurement m USING new_measurement nm ON (m.city_id = nm.city_id and m.logdate=nm.logdate) WHEN MATCHED AND nm.peaktemp IS NULL THEN DELETE WHEN MATCHED THEN UPDATE SET peaktemp = greatest(m.peaktemp, nm.peaktemp), unitsales = m.unitsales + coalesce(nm.unitsales, $1) WHEN NOT MATCHED THEN INSERT (city_id, logdate, peaktemp, unitsales) VALUES (city_id, logdate, peaktemp, unitsales)",
   "DO language E'plpgsql' 'BEGIN PERFORM 1; END'",
   "DO language $1 $2",
+  "DO U&'' '' ''",
+  "DO $1 $2 $3",
   "NOTIFY channel, 'a'",
   "NOTIFY channel, $1",
   "NOTIFY channel, 'b'",

--- a/test/normalize_utility_tests.c
+++ b/test/normalize_utility_tests.c
@@ -43,6 +43,8 @@ const char* tests[] = {
   "MERGE into measurement m USING new_measurement nm ON (m.city_id = nm.city_id and m.logdate=nm.logdate) WHEN MATCHED AND nm.peaktemp IS NULL THEN DELETE WHEN MATCHED THEN UPDATE SET peaktemp = greatest(m.peaktemp, nm.peaktemp), unitsales = m.unitsales + coalesce(nm.unitsales, 0) WHEN NOT MATCHED THEN INSERT (city_id, logdate, peaktemp, unitsales) VALUES (city_id, logdate, peaktemp, unitsales)",
   "DO language E'plpgsql' 'BEGIN PERFORM 1; END'",
   "DO language E'plpgsql' 'BEGIN PERFORM 1; END'",
+  "DO U&'' '' ''",
+  "DO U&'' '' ''",
   "NOTIFY channel, 'a'",
   "NOTIFY channel, $1",
   "NOTIFY channel, 'b'",


### PR DESCRIPTION
The earlier commit 7eee7a6a addressed single character tokens, e.g. used like E'something' and B'0101', but it did not cover unicode escape cases such as U&'d\0061t\+000061'.

To fix, reword the logic to instead trigger based on the start of the string, which should always trigger a RecordConstLocation call, but adjust the start location by walking backwards one or two characters in case they are the special escape tokens.

Per ASAN report from OSS-Fuzz.