### PR TITLE
Preserve parentheses around subscripted array constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All versions are tagged by the major Postgres version, plus an individual semver for this library itself.
 
+## 17-6.2.3   2026-08-24
+
+* Deparser:
+  - Preserve parentheses around subscripted array constructors
+    - This prevents `(ARRAY[...])[...]` from being deparsed as invalid SQL
+  - Fix handling of constraint key named `value` in `ALTER TABLE` [#329](https://github.com/pganalyze/libpg_query/pull/329)
+* Preserve `ARFLAGS` when overriding `AR` [#328](https://github.com/pganalyze/libpg_query/pull/328)
+
 ## 17-6.2.2   2026-01-26
 
 * pg_query_normalize: Fix handling of special strings in DefElem [#325](https://github.com/pganalyze/libpg_query/pull/325)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PG_VERSION_MAJOR = $(call word-dot,$(PG_VERSION),1)
 PG_VERSION_NUM = 170007
 PROTOC_VERSION = 25.1
 
-VERSION = 6.2.2
+VERSION = 6.2.3
 VERSION_MAJOR = $(call word-dot,$(VERSION),1)
 VERSION_MINOR = $(call word-dot,$(VERSION),2)
 VERSION_PATCH = $(call word-dot,$(VERSION),3)

--- a/src/postgres_deparse.c
+++ b/src/postgres_deparse.c
@@ -4639,6 +4639,7 @@ static void deparseAIndirection(DeparseState *state, A_Indirection *a_indirectio
 		IsA(a_indirection->arg, A_Expr) ||
 		IsA(a_indirection->arg, TypeCast) ||
 		IsA(a_indirection->arg, RowExpr) ||
+		IsA(a_indirection->arg, A_ArrayExpr) ||
 		(IsA(a_indirection->arg, ColumnRef) && !IsA(linitial(a_indirection->indirection), A_Indices)) ||
 		IsA(a_indirection->arg, JsonFuncExpr);
 

--- a/test/deparse_tests.c
+++ b/test/deparse_tests.c
@@ -55,6 +55,7 @@ const char* tests[] = {
   "SELECT * FROM x WHERE id NOT IN (1, 2, 3)",
   "SELECT * FROM x JOIN (SELECT n FROM z) b ON a.id = b.id",
   "SELECT * FROM x WHERE y = z[5]",
+  "SELECT (ARRAY['a', 'b'])[1]",
   "SELECT (foo(1)).y",
   "SELECT proname, (SELECT regexp_split_to_array(proargtypes::text, ' '))[idx] AS argtype, proargnames[idx] AS argname FROM pg_proc",
   "SELECT COALESCE((SELECT customer.sp_person(n.id) AS sp_person).city_id, NULL::int) AS city_id FROM customer.tb_customer n",


### PR DESCRIPTION
Array constructors require parentheses when used as the target of an indirection. Without them, deparsing `(ARRAY[...])[...]` produces SQL that cannot be parsed again.

Here we backport the A_ArrayExpr handling from the Postgres 18 branch and add a parse/deparse round-trip regression test.