### PR TITLE
Deparse: unpack the protobuf with palloc

### DIFF
--- a/src/pg_query_readfuncs_protobuf.c
+++ b/src/pg_query_readfuncs_protobuf.c
@@ -152,13 +152,27 @@ static Node * _readNode(PgQuery__Node *msg)
 	}
 }
 
+static void *unpack_palloc(void *allocator_data, size_t size)
+{
+	return palloc(size);
+}
+
+static void unpack_free_noop(void *allocator_data, void *pointer)
+{
+	/* freed wholesale when the caller's memory context is deleted */
+}
+
+static ProtobufCAllocator unpack_allocator = {
+	unpack_palloc, unpack_free_noop, NULL
+};
+
 List * pg_query_protobuf_to_nodes(PgQueryProtobuf protobuf)
 {
 	PgQuery__ParseResult *result = NULL;
 	List * list = NULL;
 	size_t i = 0;
 
-	result = pg_query__parse_result__unpack(NULL, protobuf.len, (const uint8_t *) protobuf.data);
+	result = pg_query__parse_result__unpack(&unpack_allocator, protobuf.len, (const uint8_t *) protobuf.data);
 
 	// TODO: Handle this by returning an error instead
 	Assert(result != NULL);
@@ -170,8 +184,6 @@ List * pg_query_protobuf_to_nodes(PgQueryProtobuf protobuf)
 		list = list_make1(_readRawStmt(result->stmts[0]));
     for (i = 1; i < result->n_stmts; i++)
 		list = lappend(list, _readRawStmt(result->stmts[i]));
-
-	pg_query__parse_result__free_unpacked(result, NULL);
 
 	return list;
 }


### PR DESCRIPTION
`pg_query_protobuf_to_nodes` unpacks its input with protobuf-c's default allocator, which mallocs once per message and frees via `protobuf_c_message_free_unpacked` — a walk over every field of every message's descriptor looking for pointers. The `Node` descriptor has 271 fields and every value in a parse tree is a `Node`, so ~80% of `pg_query_deparse_protobuf` is inside protobuf-c: ~45% of samples in `free_unpacked`, ~34% in `unpack`. The deparse walk itself is 6–8%.

The function has one caller, `pg_query_deparse_protobuf_opts`, which always runs it inside a pg_query memory context — the one `_readRawStmt` already `palloc`s the `Node` tree into. So this passes a `ProtobufCAllocator` backed by `palloc` and drops the free call. `MemoryContextDelete` reclaims the structs with everything else.

Measured on darwin-arm64, clang -O2, 20k iterations of `pg_query_deparse_protobuf` over a pre-parsed tree:

| statement | before | after | |
|---|---|---|---|
| `SELECT a, b FROM t WHERE c = 1` | 5.93 µs | 2.90 µs | 2.0× |
| join + correlated subquery + GROUP BY | 18.32 µs | 8.37 µs | 2.2× |
| 100-column projection | 116.98 µs | 53.45 µs | 2.2× |
| INSERT … ON CONFLICT DO UPDATE | 6.58 µs | 3.14 µs | 2.1× |

Peak memory during the call goes up. The unpacked structs stay live through the deparse instead of being freed before it, and protobuf-c's per-message scratch (a 34-byte required-fields bitmap for `Node`) is retained instead of freed inside `unpack`. On a 3 MB parse tree, peak RSS for the call goes from +25.4 MB to +38.7 MB, released when the call returns as before.

This also fixes a leak: an `elog(ERROR)` from `_readNode` used to longjmp past `free_unpacked`. The structs are now context-owned, so the existing `PG_CATCH` reclaims them.
