### PR TITLE
Return errors for PL/pgSQL statements without bodies

### DIFF
--- a/src/pg_query_parse_plpgsql.c
+++ b/src/pg_query_parse_plpgsql.c
@@ -140,7 +140,10 @@ static PLpgSQL_function *compile_do_stmt(DoStmt* stmt)
 		}
 	}
 
-	assert(proc_source != NULL);
+	if (proc_source == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("no inline code specified")));
 
 	if(strcmp(language, "plpgsql") != 0) {
 		return (PLpgSQL_function *) palloc0(sizeof(PLpgSQL_function));
@@ -421,7 +424,10 @@ compile_create_function_stmt_via_callback(CreateFunctionStmt *stmt)
 		}
 	}
 
-	assert(proc_source != NULL);
+	if (proc_source == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
+				 errmsg("no function body specified")));
 
 	if (strcmp(language, "plpgsql") != 0)
 		return (PLpgSQL_function *) palloc0(sizeof(PLpgSQL_function));
@@ -626,6 +632,7 @@ PgQueryPlpgsqlParseResult pg_query_parse_plpgsql(const char* input)
 		result.error = func_and_error.error;
 
 		if (result.error != NULL) {
+			free(parse_result.stderr_buffer);
 			pg_query_exit_memory_context(ctx);
 			return result;
 		}

--- a/test/parse_plpgsql.c
+++ b/test/parse_plpgsql.c
@@ -10,6 +10,24 @@
 #include <fcntl.h>
 #include <assert.h>
 
+static bool
+expect_error(const char *input, const char *expected_message)
+{
+	PgQueryPlpgsqlParseResult result = pg_query_parse_plpgsql(input);
+	bool success = result.error != NULL &&
+		strcmp(result.error->message, expected_message) == 0;
+
+	if (!success)
+	{
+		printf("Expected error: %s\n", expected_message);
+		printf("Actual error: %s\n",
+			result.error == NULL ? "(none)" : result.error->message);
+	}
+
+	pg_query_free_plpgsql_parse_result(result);
+	return success;
+}
+
 int main() {
 	bool ret_code = EXIT_SUCCESS;
 	char *sample_buffer;
@@ -55,6 +73,14 @@ int main() {
 	fclose(f_out);
 
 	pg_query_free_plpgsql_parse_result(result);
+
+	if (!expect_error("CREATE FUNCTION f() RETURNS void LANGUAGE plpgsql;",
+				  "no function body specified"))
+		ret_code = EXIT_FAILURE;
+
+	if (!expect_error("DO LANGUAGE plpgsql;",
+				  "no inline code specified"))
+		ret_code = EXIT_FAILURE;
 
 	pg_query_exit();
 


### PR DESCRIPTION
## Summary

- return PostgreSQL's normal errors when `CREATE FUNCTION` or `DO` omits its `AS` clause
- avoid assertion aborts and release-build NULL dereferences
- cover both malformed statement types with focused regressions

## Tests

- full test suite with AddressSanitizer and `NDEBUG`
- assertion-enabled `test/parse_plpgsql`
- standalone `CREATE FUNCTION` and `DO` reproductions in both configurations

Fixes #362.